### PR TITLE
Added new optional services (bnc#942379)

### DIFF
--- a/package/yast2-security.changes
+++ b/package/yast2-security.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Aug 19 14:55:48 UTC 2015 - ancor@suse.com
+
+- Added some entries to the list of optional services (bnc#942379)
+- 3.1.11
+
+-------------------------------------------------------------------
 Fri Jun 19 15:26:45 UTC 2015 - ancor@suse.com
 
 - Settings of security levels moved to YAML files

--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-security
-Version:        3.1.10
+Version:        3.1.11
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/data/security/services.yml
+++ b/src/data/security/services.yml
@@ -21,32 +21,41 @@ optional_services:
   - acpid
   - autofs
   - bluetooth
+  - btrfsmaintenance-refresh
   - console-kit-daemon
   - cron
   - dbus
   - display-manager
   - getty@tty1
   - haveged
+  - irqbalance
+  - iscsi
   - isdn
+  - kdump
   - klog
   - libvirtd
   - mcelog
+  - ModemManager
+  - NetworkManager-dispatcher
+  - NetworkManager-wait-online
   - nscd
   - ntpd
   - polkitd
   - postfix
-  - ModemManager
-  - NetworkManager-dispatcher
-  - NetworkManager-wait-online
+  - purge-kernels
   - random
   - sendmail
   - smartd
+  - spice-vdagentd
   - sshd
   - syslog
   - systemd-dmevented
   - systemd-journal-flush
   - systemd-journald
   - systemd-logind
+  - systemd-readahead-collect
+  - systemd-readahead-drop
+  - systemd-readahead-replay
   - systemd-udevd
   - wickedd
   - wickedd-auto4


### PR DESCRIPTION
I found this while looking into https://bugzilla.suse.com/show_bug.cgi?id=941620 (the yast2-security backport). I need it merged in order to have a smooth backport.