### PR TITLE
Remove interpretation of Ctrl + Alt + Del for s390 from Boot Permisions fate#319711

### DIFF
--- a/package/yast2-security.changes
+++ b/package/yast2-security.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Feb 26 12:40:29 UTC 2016 - knut.anderssen@suse.com
+
+- Removed "Boot permissions - Interpretation"  of Ctrl + Alt + Del
+  for s390. (fate#319711)
+- 3.2.1
+
+-------------------------------------------------------------------
 Thu Sep 24 14:50:20 UTC 2015 - ancor@suse.com
 
 - Bumped version number in order to branch the SLE version due to

--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-security
-Version:        3.2.0
+Version:        3.2.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/include/security/dialogs.rb
+++ b/src/include/security/dialogs.rb
@@ -573,7 +573,7 @@ module Yast
     def BootDialog
       # Boot dialog caption
       caption = _("Boot Settings")
-      help = Ops.get_string(@HELPS, "boot", "")
+      help = @HELPS["boot"] || ""
 
       # Boot dialog contents
       contents = HVCenter(
@@ -587,15 +587,7 @@ module Yast
                 _("Boot Permissions"),
                 HBox(
                   HSpacing(3),
-                  VBox(
-                    VSpacing(1),
-                    settings2widget("CONSOLE_SHUTDOWN"),
-                    VSpacing(1.0),
-                    settings2widget("AllowShutdown"),
-                    VSpacing(1.0),
-                    settings2widget("HIBERNATE_SYSTEM"),
-                    VSpacing(1)
-                  ),
+                  boot_vbox_widgets,
                   HSpacing(3)
                 )
               ),
@@ -649,7 +641,7 @@ module Yast
       end
 
       if ret == :next || Builtins.contains(@tree_dialogs, ret)
-        widget2settings("CONSOLE_SHUTDOWN")
+        widget2settings("CONSOLE_SHUTDOWN") if !Arch.s390
         widget2settings("AllowShutdown")
         widget2settings("HIBERNATE_SYSTEM")
       end
@@ -973,5 +965,18 @@ module Yast
 
       deep_copy(ret)
     end
+
+    def boot_vbox_widgets
+      VBox(
+        VSpacing(1),
+        Arch.s390 ? Empty() : settings2widget("CONSOLE_SHUTDOWN"),
+        Arch.s390 ? Empty() : VSpacing(1.0),
+        settings2widget("AllowShutdown"),
+        VSpacing(1.0),
+        settings2widget("HIBERNATE_SYSTEM"),
+        VSpacing(1)
+      )
+    end
+
   end
 end

--- a/src/include/security/helps.rb
+++ b/src/include/security/helps.rb
@@ -52,28 +52,7 @@ module Yast
             "<p><b><big>Aborting Saving</big></b><br>\nAbort the save procedure by pressing <b>Abort</b>.</p>"
           ),
         # Boot dialog help 1/4
-        "boot"           => _(
-          "<p><b><big>Boot Security</big></b></p>\n<p>In this dialog, change various boot settings related to security.</p>"
-        ) +
-          # Boot dialog help 2/4
-          _(
-            "<p><b>Interpretation of Ctrl + Alt + Del</b>:\n" +
-              "Configure what the system should do in response to\n" +
-              "someone at the console pressing the CTRL + ALT + DEL key\n" +
-              "combination. Usually the system reboots. Sometimes it is desirable\n" +
-              "to ignore this event, for example, when the system serves as both\n" +
-              "workstation and server.</p>"
-          ) +
-          # Boot dialog help 3/4
-          _(
-            "<p><b>Shutdown Behaviour of Login Manager</b>:\nSet who is allowed to shut down the machine from KDM.</p>\n"
-          ) +
-          # Boot dialog help 4/4
-          _(
-            "<p><b>Hibernate System</b>:\n" +
-              "Set the conditions for allowing users to hibernate the system. By default, user on active console has such right.\n" +
-              "Other options are allowing the action to any user or requiring authentication in all cases.</p>\n"
-          ),
+        "boot"           => boot_dialog_help,
         # Main dialog help 1/8
         "main"           => _(
           "<P><BIG><B>Configuring Local Security</B></BIG></P>\n" +
@@ -352,8 +331,37 @@ module Yast
         "EXTRA_SERVICES"                            => _(
           "<P>Every running service is a potential target of a security attack. Therefore it is recommended to turn off all services which are not used by the system.</P>"
         )
-      } 
+      }
 
+    end
+
+    def boot_dialog_help
+      help = _(
+        "<p><b><big>Boot Security</big></b></p>\n<p>In this dialog, change various boot settings related to security.</p>"
+      )
+
+      # Boot dialog help 2/4, not shown for s390 architecture
+      help << _(
+        "<p><b>Interpretation of Ctrl + Alt + Del</b>:\n" +
+          "Configure what the system should do in response to\n" +
+          "someone at the console pressing the CTRL + ALT + DEL key\n" +
+          "combination. Usually the system reboots. Sometimes it is desirable\n" +
+          "to ignore this event, for example, when the system serves as both\n" +
+          "workstation and server.</p>"
+      ) if !Arch.s390
+
+      help <<
+        # Boot dialog help 3/4
+        _(
+          "<p><b>Shutdown Behaviour of Login Manager</b>:\nSet who is allowed to shut down the machine from KDM.</p>\n"
+        ) +
+        # Boot dialog help 4/4
+        _(
+          "<p><b>Hibernate System</b>:\n" +
+            "Set the conditions for allowing users to hibernate the system. By default, user on active console has such right.\n" +
+            "Other options are allowing the action to any user or requiring authentication in all cases.</p>\n"
+        )
+      help
 
       # EOF
     end


### PR DESCRIPTION
I had tested mocking Arch.s390 and also in SP1 but, modifying the code because the AllowShutdown option was not called so and also was dropped from the menu. 

I'm trying to reproduce in a SP2, but if it is not mandatory could be merged.