### PR TITLE
Add more info to changelog to help tracking

### DIFF
--- a/package/yast2-security.changes
+++ b/package/yast2-security.changes
@@ -51,7 +51,7 @@ Fri Jun 12 16:27:53 UTC 2015 - ancor@suse.com
 Thu Jun 11 16:00:10 UTC 2015 - ancor@suse.com
 
 - Removed references to runlevels (obsolete). Only current systemd
-  target is analyzed.
+  target is analyzed. (fate#318425, bnc#941620)
 - List of mandatory and optional services moved to a YAML file.
 
 -------------------------------------------------------------------


### PR DESCRIPTION
I got this mail from the maintenance team:

> Maintenance identified that some fixes planned for the next update of this package are not referenced in the change log of the package that was accepted into SUSE:SLE-12-SP2:GA.

> We would like to ask your help to verify if these bugs are fixed or not in SLE 12-SP2. In case they are not, please submit the fixes as soon as possible to SUSE:SLE-12-SP2:GA. If they are already fixed
(perhaps the package was updated to a new major version which is no longer affected by the bug), we would appreciate if you could still add a reference to the package's change log.

> If there's no known fix for this bug yet or our data is incorrect, please reply to this mail to let us know.

> Here is the bug https://bugzilla.suse.com/buglist.cgi?bug_id=941620

Since the bug ended up being a request to backports the changes that were already in SP1, this is the only way to please the maintenance team. Once merged, I will manually create the SR to factory and SP2.