### PR TITLE
Write sysctl settings to /etc/sysctl.d

### DIFF
--- a/package/yast2-security.changes
+++ b/package/yast2-security.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Oct  3 16:28:06 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Place sysctl settings in /etc/sysctl.d/ (jsc#SLE-9077).
+- 4.2.4
+
+-------------------------------------------------------------------
 Fri Sep 27 13:10:44 CEST 2019 - schubi@suse.de
 
 - AY: Settings have not been exported. "console_shutdown" entry

--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -45,7 +45,7 @@ BuildRequires: rubygem(%{rb_default_ruby_abi}:yast-rake-ci)
 
 # new Pam.ycp API
 Requires:       yast2-pam >= 2.14.0
-# Yast2::CFA::Sysctl
+# CFA::Sysctl
 Requires:       yast2 >= 4.2.25
 Requires:       yast2-ruby-bindings >= 1.0.0
 

--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-security
-Version:        4.2.3
+Version:        4.2.4
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only
@@ -34,8 +34,8 @@ BuildRequires:  yast2-pam
 BuildRequires:  yast2-devtools >= 4.2.2
 BuildRequires:  rubygem(%{rb_default_ruby_abi}:yast-rake) >= 0.2.5
 BuildRequires:  rubygem(%{rb_default_ruby_abi}:rspec)
-# Yast2::Systemd::Service
-BuildRequires:  yast2 >= 4.1.3
+# Yast2::CFA::Sysctl
+BuildRequires:  yast2 >= 4.2.25
 # Unfortunately we cannot move this to macros.yast,
 # bcond within macros are ignored by osc/OBS.
 %bcond_with yast_run_ci_tests
@@ -45,8 +45,8 @@ BuildRequires: rubygem(%{rb_default_ruby_abi}:yast-rake-ci)
 
 # new Pam.ycp API
 Requires:       yast2-pam >= 2.14.0
-# Yast2::Systemd::Service
-Requires:       yast2 >= 4.1.3
+# Yast2::CFA::Sysctl
+Requires:       yast2 >= 4.2.25
 Requires:       yast2-ruby-bindings >= 1.0.0
 
 Provides:       y2c_sec yast2-config-security

--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -27,7 +27,7 @@
 # $Id$
 require "yast"
 require "yast2/systemd/service"
-require "yast2/cfa/sysctl"
+require "cfa/sysctl"
 require "yaml"
 require "security/ctrl_alt_del_config"
 require "security/display_manager"
@@ -346,7 +346,7 @@ module Yast
     def read_kernel_settings
       # NOTE: the call to #sort is only needed to satisfy the old testsuite
       @sysctl.sort.each do |key, default_value|
-        val = sysctl_file[key]
+        val = read_sysctl_value(key)
         val = default_value if val.nil? || val == ""
         @Settings[key] = val
       end
@@ -563,8 +563,8 @@ module Yast
         int_val = Integer(val) rescue nil
         if int_val.nil?
           log.error "value #{val} for #{key} is not integer, not writing"
-        elsif val != sysctl_file[key]
-          sysctl_file[key] = val
+        elsif val != read_sysctl_value(key)
+          write_sysctl_value(key, val)
           written = true
         end
       end
@@ -831,9 +831,28 @@ module Yast
     # @return [Yast2::CFA::Sysctl]
     def sysctl_file
       return @sysctl_file if @sysctl_file
-      @sysctl_file = Yast2::CFA::Sysctl.new
+      @sysctl_file = CFA::Sysctl.new
       @sysctl_file.load
       @sysctl_file
+    end
+
+    # Map sysctl keys to method names from the CFA::Sysctl class.
+    SYSCTL_KEY_TO_METH = {
+      "kernel.sysrq"                 => :kernel_sysrq,
+      "net.ipv4.tcp_syncookies"      => :raw_tcp_syncookies,
+      "net.ipv4.ip_forward"          => :raw_forward_ipv4,
+      "net.ipv6.conf.all.forwarding" => :raw_forward_ipv6
+    }.freeze
+
+    # @param key [String] Key to get the value for
+    def read_sysctl_value(key)
+      sysctl_file.public_send(SYSCTL_KEY_TO_METH[key])
+    end
+
+    # @param key    [String] Key to set the value for
+    # @return value [String] Value to assign to the given key
+    def write_sysctl_value(key, value)
+      sysctl_file.public_send(SYSCTL_KEY_TO_METH[key].to_s + "=", value)
     end
   end
 

--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -27,6 +27,7 @@
 # $Id$
 require "yast"
 require "yast2/systemd/service"
+require "yast2/cfa/sysctl"
 require "yaml"
 require "security/ctrl_alt_del_config"
 require "security/display_manager"
@@ -238,6 +239,8 @@ module Yast
       @proposal_valid = false
       @write_only = false
 
+      # Force reading of sysctl configuration
+      @sysctl_file = nil
 
       @activation_mapping = {
         "SYSLOG_ON_NO_ERROR"           => "/etc/init.d/boot.clock start",
@@ -343,7 +346,7 @@ module Yast
     def read_kernel_settings
       # NOTE: the call to #sort is only needed to satisfy the old testsuite
       @sysctl.sort.each do |key, default_value|
-        val = SCR.Read(path(".etc.sysctl_conf") + key)
+        val = sysctl_file[key]
         val = default_value if val.nil? || val == ""
         @Settings[key] = val
       end
@@ -560,12 +563,12 @@ module Yast
         int_val = Integer(val) rescue nil
         if int_val.nil?
           log.error "value #{val} for #{key} is not integer, not writing"
-        elsif val != SCR.Read(path(".etc.sysctl_conf") + key)
-          SCR.Write(path(".etc.sysctl_conf") + key, val)
+        elsif val != sysctl_file[key]
+          sysctl_file[key] = val
           written = true
         end
       end
-      SCR.Write(path(".etc.sysctl_conf"), nil) if written
+      sysctl_file.save if written
 
       # enable sysrq?
       sysrq = Integer(@Settings.fetch("kernel.sysrq", "0")) rescue nil
@@ -819,6 +822,18 @@ module Yast
       end
       @extra_services.map!(&:name)
       log.info("All extra services: #{@extra_services}")
+    end
+
+    # Returns the sysctl configuration
+    #
+    # @note It memoizes the value until {#main} is called.
+    #
+    # @return [Yast2::CFA::Sysctl]
+    def sysctl_file
+      return @sysctl_file if @sysctl_file
+      @sysctl_file = Yast2::CFA::Sysctl.new
+      @sysctl_file.load
+      @sysctl_file
     end
   end
 

--- a/test/security_test.rb
+++ b/test/security_test.rb
@@ -36,10 +36,10 @@ module Yast
   import "Service"
 
   describe Security do
-    let(:sysctl_file) { Yast2::CFA::Sysctl.new }
+    let(:sysctl_file) { CFA::Sysctl.new }
 
     before do
-      allow(Yast2::CFA::Sysctl).to receive(:new).and_return(sysctl_file)
+      allow(CFA::Sysctl).to receive(:new).and_return(sysctl_file)
       allow(sysctl_file).to receive(:save)
       Security.main
     end
@@ -184,20 +184,20 @@ module Yast
         it "does not write invalid values" do
           Security.Settings["kernel.sysrq"] = "yes"
           Security.Settings["net.ipv4.ip_forward"] = ""
-          expect(sysctl_file).to_not receive(:[]=).with("kernel.sysreq", "yes")
-          expect(sysctl_file).to_not receive(:[]=).with("net.ipv4.ip_forward", "")
+          expect(sysctl_file).to_not receive(:kernel_sysrq).with("yes")
+          expect(sysctl_file).to_not receive(:raw_forward_ipv4=).with("")
           Security.write_kernel_settings
         end
 
         it "does not write unchanged values" do
           Security.Settings["net.ipv4.ip_forward"] = "0"
-          expect(sysctl_file).to_not receive(:[]=).with("net.ipv4.ip_forward", "0")
+          expect(sysctl_file).to_not receive(:raw_forward_ipv4=).with("0")
           Security.write_kernel_settings
         end
 
         it "writes changed values" do
           Security.Settings["net.ipv4.ip_forward"] = "1"
-          expect(sysctl_file).to receive(:[]=).with("net.ipv4.ip_forward", "1")
+          expect(sysctl_file).to receive(:raw_forward_ipv4=).with("1")
           expect(sysctl_file).to receive(:save)
           Security.write_kernel_settings
         end

--- a/test/security_test.rb
+++ b/test/security_test.rb
@@ -36,6 +36,14 @@ module Yast
   import "Service"
 
   describe Security do
+    let(:sysctl_file) { Yast2::CFA::Sysctl.new }
+
+    before do
+      allow(Yast2::CFA::Sysctl).to receive(:new).and_return(sysctl_file)
+      allow(sysctl_file).to receive(:save)
+      Security.main
+    end
+
     describe "#ReadServiceSettings" do
       let(:aliases) { {} }
 
@@ -174,27 +182,24 @@ module Yast
         end
 
         it "does not write invalid values" do
-          expect(SCR).to_not receive(:Write)
-
           Security.Settings["kernel.sysrq"] = "yes"
           Security.Settings["net.ipv4.ip_forward"] = ""
+          expect(sysctl_file).to_not receive(:[]=).with("kernel.sysreq", "yes")
+          expect(sysctl_file).to_not receive(:[]=).with("net.ipv4.ip_forward", "")
           Security.write_kernel_settings
         end
 
         it "does not write unchanged values" do
-          expect(SCR).to_not receive(:Write)
-
           Security.Settings["net.ipv4.ip_forward"] = "0"
+          expect(sysctl_file).to_not receive(:[]=).with("net.ipv4.ip_forward", "0")
           Security.write_kernel_settings
         end
 
         it "writes changed values" do
           Security.Settings["net.ipv4.ip_forward"] = "1"
+          expect(sysctl_file).to receive(:[]=).with("net.ipv4.ip_forward", "1")
+          expect(sysctl_file).to receive(:save)
           Security.write_kernel_settings
-
-          expect(written_value_for(".etc.sysctl_conf.net.ipv4.ip_forward"))
-            .to eq("1")
-          expect(was_written?(".etc.sysctl_conf")).to eq(true)
         end
       end
 


### PR DESCRIPTION
Adapts sysctl handling to use the new [Yast2::CFA::Sysctl](https://github.com/yast/yast-yast2/pull/966) class so the configuration is written to a YaST specific file under `/etc/sysctl.d`.