### PR TITLE
Change default encrypt method

### DIFF
--- a/package/yast2-security.changes
+++ b/package/yast2-security.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Nov 22 12:21:59 UTC 2019 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Change default encryption method from DES to SHA512 (bsc#1157541,
+  CVE-2019-3700).
+- 4.2.6
+
+-------------------------------------------------------------------
 Fri Oct 18 13:06:46 CEST 2019 - schubi@suse.de
 
 - Added extra_services to security.rnc file (bsc#1153623).

--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-security
-Version:        4.2.5
+Version:        4.2.6
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/clients/security.rb
+++ b/src/clients/security.rb
@@ -210,7 +210,7 @@ module Yast
         Ops.set(
           Security.Settings,
           "PASSWD_ENCRYPTION",
-          Ops.get_string(options, "passwd", "des")
+          Ops.get_string(options, "passwd", Security.default_encrypt_method)
         )
         Security.modified = true
       end

--- a/src/clients/security_auto.rb
+++ b/src/clients/security_auto.rb
@@ -85,7 +85,7 @@ module Yast
           Ops.set(
             @param,
             "passwd_encryption",
-            Ops.get_string(@param, "encryption", "des")
+            Ops.get_string(@param, "encryption", Security.default_encrypt_method)
           )
         end
         @ret = Security.Import(

--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -35,6 +35,7 @@ require "security/display_manager"
 module Yast
   class SecurityClass < Module
     DEFAULT_ENCRYPT_METHOD = "sha512".freeze
+    private_constant :DEFAULT_ENCRYPT_METHOD
 
     include Yast::Logger
     include ::Security::CtrlAltDelConfig

--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -34,6 +34,7 @@ require "security/display_manager"
 
 module Yast
   class SecurityClass < Module
+    DEFAULT_ENCRYPT_METHOD = "sha512".freeze
 
     include Yast::Logger
     include ::Security::CtrlAltDelConfig
@@ -357,7 +358,7 @@ module Yast
     def read_encryption_method
       method = SCR.Read(path(".etc.login_defs.ENCRYPT_METHOD")).to_s.downcase
 
-      method = "des" if !@encryption_methods.include?(method)
+      method = "sha512" if !@encryption_methods.include?(method)
 
       @Settings["PASSWD_ENCRYPTION"] = method
     end
@@ -518,7 +519,7 @@ module Yast
     # Write settings related to PAM behavior
     def write_pam_settings
       # pam stuff
-      encr = @Settings.fetch("PASSWD_ENCRYPTION", "sha512")
+      encr = @Settings.fetch("PASSWD_ENCRYPTION", default_encrypt_method)
       if encr != @Settings_bak["PASSWD_ENCRYPTION"]
         SCR.Write(path(".etc.login_defs.ENCRYPT_METHOD"), encr)
       end
@@ -763,6 +764,13 @@ module Yast
     # @return table items
     def Overview
       []
+    end
+
+    # Expose the default encryption method to other parts of the module
+    #
+    # @return [String]
+    def default_encrypt_method
+      DEFAULT_ENCRYPT_METHOD
     end
 
     publish :variable => :mandatory_services, :type => "const list <list <string>>"


### PR DESCRIPTION
## Problem

After moving the `/etc/login.defs` to `/usr/etc/login.defs`, YaST2 security does not find the current configuration. The problem is that the fallback encryption method is `des`, which causes users/groups passwords to use that method instead of `sha512`.

See https://bugzilla.suse.com/show_bug.cgi?id=1157541

## Solution

Use `sha512` as default. In the screenshot below you can see the `/etc/shadow` content and the security settings screen after applying the patch.

![yast2-security](https://user-images.githubusercontent.com/15836/69425644-3dcbbc00-0d23-11ea-86f9-8f6921024e3a.png)
