### PR TITLE
don't use /bin/systemctl compat symlink (bsc#1160890)

### DIFF
--- a/package/yast2-security.changes
+++ b/package/yast2-security.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Jan 23 13:04:04 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
+
+- don't use /bin/systemctl compat symlink (bsc#1160890)
+- 4.2.10
+
+-------------------------------------------------------------------
 Mon Jan 13 12:22:00 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - convert old init.d to systemd (jsc#SLE-10976)

--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-security
-Version:        4.2.9
+Version:        4.2.10
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -248,13 +248,13 @@ module Yast
       @sysctl_file = nil
 
       @activation_mapping = {
-        "DHCPD_RUN_CHROOTED"           => "/bin/systemctl try-restart dhcpd.service",
-        "DHCPD_RUN_AS"                 => "/bin/systemctl try-restart dhcpd.service",
+        "DHCPD_RUN_CHROOTED"           => "/usr/bin/systemctl try-restart dhcpd.service",
+        "DHCPD_RUN_AS"                 => "/usr/bin/systemctl try-restart dhcpd.service",
         # restart sendmail or postfix - whatever is installed
-        "SMTPD_LISTEN_REMOTE"          => "/bin/systemctl try-restart sendmail postfix",
-        "net.ipv4.tcp_syncookies"      => "/bin/systemctl try-restart network",
-        "net.ipv4.ip_forward"          => "/bin/systemctl try-restart network",
-        "net.ipv6.conf.all.forwarding" => "/bin/systemctl try-restart network"
+        "SMTPD_LISTEN_REMOTE"          => "/usr/bin/systemctl try-restart sendmail postfix",
+        "net.ipv4.tcp_syncookies"      => "/usr/bin/systemctl try-restart network",
+        "net.ipv4.ip_forward"          => "/usr/bin/systemctl try-restart network",
+        "net.ipv6.conf.all.forwarding" => "/usr/bin/systemctl try-restart network"
       }
 
       @shadow_config = nil


### PR DESCRIPTION
## Problem

https://bugzilla.suse.com/show_bug.cgi?id=1160890
https://trello.com/c/3Y9HSV8m

`/bin/systemctl` symlink is gone.

## Solution

Don't use it.