### PR TITLE
Apply sysctl changes (bsc#1167234)

### DIFF
--- a/package/yast2-security.changes
+++ b/package/yast2-security.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Mar 31 17:41:17 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
+
+- Apply sysctl changes to the running system when the YaST sysctl
+  configuration file is modified (bsc#1167234)
+- 4.2.12
+
+-------------------------------------------------------------------
 Mon Feb  3 16:02:35 CET 2020 - schubi@suse.de
 
 - Using SysctlConfig class: Handle sysctl entries in different

--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-security
-Version:        4.2.11
+Version:        4.2.12
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -617,9 +617,9 @@ module Yast
     # applies the changes system wide. Otherwise it only applies the changes
     # from the sysctl YaST config file.
     def apply_sysctl_changes
-      args = sysctl_conflict? ? ["--system"] : ["-p", CFA::Sysctl::PATH]
+      args = sysctl_config.conflict? ? ["--system"] : ["-p", CFA::Sysctl::PATH]
 
-      Yast::Execute.on_target("/sbin/sysctl", *args)
+      Yast::Execute.on_target("/usr/sbin/sysctl", *args)
     end
 
     # Ensures that sysctl changes, file permissions and PolicyKit privileges
@@ -903,10 +903,6 @@ module Yast
       @sysctl_config = CFA::SysctlConfig.new
       @sysctl_config.load
       @sysctl_config
-    end
-
-    def sysctl_conflict?
-      @conflict ||= sysctl_config.conflict?
     end
 
     # Map sysctl keys to method names from the CFA::SysctlConfig class.

--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -591,6 +591,7 @@ module Yast
         end
       end
 
+      # In case of modified, always write the changes (bsc#1167234)
       sysctl_config.save if written
       written
     end
@@ -621,8 +622,12 @@ module Yast
       Yast::Execute.on_target("/sbin/sysctl", *args)
     end
 
-    # Ensures that file permissions and PolicyKit privileges are applied
+    # Ensures that sysctl changes, file permissions and PolicyKit privileges
+    # are applied
+    #
+    # @param sysctl [Boolean] whether sysctl changes should be applied or not
     def apply_new_settings(sysctl: false)
+      # Apply sysctl changes to the running system (bsc#1167234)
       apply_sysctl_changes if sysctl
       # apply all current permissions as they are now
       # (what SuSEconfig --module permissions would have done)

--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -611,15 +611,12 @@ module Yast
       end
     end
 
-    # Apply sysctl changes into the running system.
-    #
-    # When the sysctl YaST config file conflicts with other sysctl files, it
-    # applies the changes system wide. Otherwise it only applies the changes
-    # from the sysctl YaST config file.
+    # Apply sysctl settings from all the sysctl configuration files
     def apply_sysctl_changes
-      args = sysctl_config.conflict? ? ["--system"] : ["-p", CFA::Sysctl::PATH]
+      # Reports if there are conflict when the configuration is applied
+      sysctl_config.conflict?
 
-      Yast::Execute.on_target("/usr/sbin/sysctl", *args)
+      Yast::Execute.on_target("/usr/sbin/sysctl", "--system")
     end
 
     # Ensures that sysctl changes, file permissions and PolicyKit privileges

--- a/test/levels_test.rb
+++ b/test/levels_test.rb
@@ -25,13 +25,15 @@ module Yast
     subject(:settings) { tester.Levels }
 
     let(:shadow_config) { CFA::ShadowConfig.new }
+    let(:sysctl_config) { CFA::SysctlConfig.new }
 
     before do
       tester
       allow(CFA::ShadowConfig).to receive(:load).and_return(shadow_config)
       allow(shadow_config).to receive(:save)
+      allow(Security).to receive(:sysctl_config).and_return(sysctl_config)
       allow(Security).to receive(:write_kernel_settings).and_return(true)
-      allow(Security).to receive(:sysctl_conflict?).and_return(false)
+      allow(sysctl_config).to receive(:conflict?).and_return(false)
     end
 
     it "reads the settings from the yaml files" do
@@ -65,7 +67,7 @@ module Yast
         expect(SCR).to exec_bash_output("/usr/sbin/pam-config -d --pwhistory-remember")
           .and_return(empty_bash_output)
         expect(SCR).to exec_bash("ln -s -f /dev/null /etc/systemd/system/ctrl-alt-del.target")
-        expect(Yast::Execute).to receive(:on_target).with("/sbin/sysctl", "-p", CFA::Sysctl::PATH)
+        expect(Yast::Execute).to receive(:on_target).with("/usr/sbin/sysctl", "-p", CFA::Sysctl::PATH)
         expect(SCR).to exec_bash("/usr/bin/chkstat --system")
         expect(shadow_config).to receive(:fail_delay=).with("6")
 

--- a/test/levels_test.rb
+++ b/test/levels_test.rb
@@ -32,8 +32,8 @@ module Yast
       allow(CFA::ShadowConfig).to receive(:load).and_return(shadow_config)
       allow(shadow_config).to receive(:save)
       allow(Security).to receive(:sysctl_config).and_return(sysctl_config)
+      allow(sysctl_config).to receive(:conflict?)
       allow(Security).to receive(:write_kernel_settings).and_return(true)
-      allow(sysctl_config).to receive(:conflict?).and_return(false)
     end
 
     it "reads the settings from the yaml files" do
@@ -67,7 +67,7 @@ module Yast
         expect(SCR).to exec_bash_output("/usr/sbin/pam-config -d --pwhistory-remember")
           .and_return(empty_bash_output)
         expect(SCR).to exec_bash("ln -s -f /dev/null /etc/systemd/system/ctrl-alt-del.target")
-        expect(Yast::Execute).to receive(:on_target).with("/usr/sbin/sysctl", "-p", CFA::Sysctl::PATH)
+        expect(Yast::Execute).to receive(:on_target).with("/usr/sbin/sysctl", "--system")
         expect(SCR).to exec_bash("/usr/bin/chkstat --system")
         expect(shadow_config).to receive(:fail_delay=).with("6")
 

--- a/test/security_test.rb
+++ b/test/security_test.rb
@@ -162,30 +162,22 @@ module Yast
     end
 
     describe "#apply_sysctl_changes" do
-      let(:conflict) { true }
-
       before do
         allow(Security).to receive(:sysctl_config).and_return(sysctl_config)
-        allow(sysctl_config).to receive(:conflict?).and_return(conflict)
+        allow(sysctl_config).to receive(:conflict?)
+        allow(Yast::Execute).to receive(:on_target).with("/usr/sbin/sysctl", "--system")
       end
 
-      context "when sysctl changes conflicts with other files" do
-        it "applies the changes system wide" do
-          expect(Yast::Execute).to receive(:on_target).with("/usr/sbin/sysctl", "--system")
+      it "checks if there are sysctl conflicts with other files" do
+        expect(sysctl_config).to receive(:conflict?)
 
-          Security.apply_sysctl_changes
-        end
+        Security.apply_sysctl_changes
       end
 
-      context "when sysctl changes do not conflict with other files" do
-        let(:conflict) { false }
+      it "applies the changes from all the configuration files" do
+        expect(Yast::Execute).to receive(:on_target).with("/usr/sbin/sysctl", "--system")
 
-        it "applies only the YaST sysctl config file changes" do
-          expect(Yast::Execute).to receive(:on_target)
-            .with("/usr/sbin/sysctl", "-p", CFA::Sysctl::PATH)
-
-          Security.apply_sysctl_changes
-        end
+        Security.apply_sysctl_changes
       end
     end
 

--- a/test/security_test.rb
+++ b/test/security_test.rb
@@ -165,12 +165,13 @@ module Yast
       let(:conflict) { true }
 
       before do
-        allow(Security).to receive(:sysctl_conflict?).and_return(conflict)
+        allow(Security).to receive(:sysctl_config).and_return(sysctl_config)
+        allow(sysctl_config).to receive(:conflict?).and_return(conflict)
       end
 
       context "when sysctl changes conflicts with other files" do
         it "applies the changes system wide" do
-          expect(Yast::Execute).to receive(:on_target).with("/sbin/sysctl", "--system")
+          expect(Yast::Execute).to receive(:on_target).with("/usr/sbin/sysctl", "--system")
 
           Security.apply_sysctl_changes
         end
@@ -181,7 +182,7 @@ module Yast
 
         it "applies only the YaST sysctl config file changes" do
           expect(Yast::Execute).to receive(:on_target)
-            .with("/sbin/sysctl", "-p", CFA::Sysctl::PATH)
+            .with("/usr/sbin/sysctl", "-p", CFA::Sysctl::PATH)
 
           Security.apply_sysctl_changes
         end

--- a/test/security_test.rb
+++ b/test/security_test.rb
@@ -38,6 +38,7 @@ module Yast
   describe Security do
     let(:sysctl_config) { CFA::SysctlConfig.new }
     let(:shadow_config) { CFA::ShadowConfig.new }
+    let(:bash_path) { Yast::Path.new(".target.bash") }
 
     before do
       allow(CFA::SysctlConfig).to receive(:new).and_return(sysctl_config)
@@ -121,6 +122,72 @@ module Yast
       end
     end
 
+    describe "#apply_new_settings" do
+      before do
+        allow(Security).to receive(:apply_sysctl_changes)
+        allow(Yast::SCR).to receive(:Execute)
+      end
+
+      context "when the sysctl config is modified" do
+        it "applies sysctl changes" do
+          expect(Security).to receive(:apply_sysctl_changes)
+
+          Security.apply_new_settings(sysctl: true)
+        end
+      end
+
+      context "when the sysctl config is not modified" do
+        it "does not apply sysctl changes" do
+          expect(Security).to_not receive(:apply_sysctl_changes)
+
+          Security.apply_new_settings
+        end
+      end
+
+      it "applies all current permissions as they are now" do
+        expect(Yast::SCR).to receive(:Execute)
+          .with(bash_path, "/usr/bin/chkstat --system")
+
+        Security.apply_new_settings
+      end
+
+      it "ensures polkit privileges are applied" do
+        expect(FileUtils)
+          .to receive(:Exists).with("/sbin/set_polkit_default_privs").and_return(true)
+        expect(Yast::SCR).to receive(:Execute)
+          .with(bash_path, "/sbin/set_polkit_default_privs")
+
+        Security.apply_new_settings
+      end
+    end
+
+    describe "#apply_sysctl_changes" do
+      let(:conflict) { true }
+
+      before do
+        allow(Security).to receive(:sysctl_conflict?).and_return(conflict)
+      end
+
+      context "when sysctl changes conflicts with other files" do
+        it "applies the changes system wide" do
+          expect(Yast::Execute).to receive(:on_target).with("/sbin/sysctl", "--system")
+
+          Security.apply_sysctl_changes
+        end
+      end
+
+      context "when sysctl changes do not conflict with other files" do
+        let(:conflict) { false }
+
+        it "applies only the YaST sysctl config file changes" do
+          expect(Yast::Execute).to receive(:on_target)
+            .with("/sbin/sysctl", "-p", CFA::Sysctl::PATH)
+
+          Security.apply_sysctl_changes
+        end
+      end
+    end
+
     describe "#write_to_locations" do
       before do
         change_scr_root(File.join(DATA_PATH, "system"))
@@ -201,34 +268,34 @@ module Yast
           Security.Settings["net.ipv4.ip_forward"] = ""
           expect(sysctl_config).to_not receive(:kernel_sysrq).with("yes")
           expect(sysctl_config).to_not receive(:raw_forward_ipv4=).with("")
-          Security.write_kernel_settings
+          expect(Security.write_kernel_settings).to eq(false)
         end
 
         it "does not write unchanged values" do
           Security.Settings["net.ipv4.ip_forward"] = false
           expect(sysctl_config).to_not receive(:save)
           Security.write_kernel_settings
+          expect(Security.write_kernel_settings).to eq(false)
         end
 
         it "writes changed values" do
           Security.Settings["net.ipv4.ip_forward"] = true
           expect(sysctl_config).to receive(:save)
           Security.write_kernel_settings
+          expect(Security.write_kernel_settings).to eq(true)
         end
       end
 
       context "setting sysrq" do
         it "does not write invalid values" do
-          expect(SCR).to_not exec_bash(/echo .* \/kernel\/sysrq/)
-
           Security.Settings["kernel.sysrq"] = "yes"
+          expect(sysctl_config).to_not receive(:save)
           Security.write_kernel_settings
         end
 
         it "writes valid values" do
-          expect(SCR).to exec_bash("echo 1 > /proc/sys/kernel/sysrq")
-
           Security.Settings["kernel.sysrq"] = "1"
+          expect(sysctl_config).to receive(:save)
           Security.write_kernel_settings
         end
       end


### PR DESCRIPTION
## Problem

This module manage some YaST sysctl config file attributes. But, after modifying the settings it does not apply the network changes to the running system. 

In the past that responsibility was handle by `boot.ipconfig` but it is not the case anymore once we moved to systemd. 

Currently, if there is at least a conflict with other sysctl config files, the error is reported but the changes are not written as you can check in the code:

https://github.com/yast/yast-security/blob/master/src/modules/Security.rb#L594

https://github.com/yast/yast-yast2/pull/1021/files#diff-4216cbac8e98ed10343a00513e10e917R128

Thus, the changes done in the UI are lost, and need to be modified manually later.

- https://trello.com/c/MoWIKnDK/1754-3-sles15-sp2-p2-1167234-ipforwarding-in-yast2-security-sets-new-value-only-in-etc-not-in-proc
- https://bugzilla.suse.com/show_bug.cgi?id=1167234

## Solution

- The sysctl changes made by the module should be written always to not lost them.
- If there is some yast sysctl config file change, then the changes will be applied to the running system. 
    - in case of a conflict it will be reported and the changes will be applied system wide **(sysctl --system)**, which means that higher precedence values will be applied instead of the yast ones, but no conflicting attributes will be applied fine. Basically the same that would be applied by rebooting the system.
    - In case of no conflict, then, only the changes of the yast sysctl config file will be applied **(sysctl -p /etc/sysctl.d/70-yast.conf)**. This is faster, and should be safe enough.


## Test

- Tested manually
- Added unit tests

## Screenshots

![Conflicting attribute](https://user-images.githubusercontent.com/7056681/78117391-85630280-73fd-11ea-8972-db0db23f91bb.png)
