### PR TITLE
Use pam_pwquality instead of pam_cracklib depending on availability

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,505 @@
+# use the shared YaST defaults
+inherit_from:
+  /usr/share/YaST2/data/devtools/data/rubocop-0.71.0_yast_style.yml
+
+# Offense count: 1
+# Cop supports --auto-correct.
+# Configuration parameters: EnforcedStyle, IndentationWidth.
+# SupportedStyles: outdent, indent
+Layout/AccessModifierIndentation:
+  Exclude:
+    - 'src/modules/Security.rb'
+
+# Offense count: 2
+# Cop supports --auto-correct.
+# Configuration parameters: EnforcedStyle, IndentationWidth.
+# SupportedStyles: with_first_argument, with_fixed_indentation
+Layout/AlignArguments:
+  Exclude:
+    - 'src/include/security/dialogs.rb'
+
+# Offense count: 11
+# Cop supports --auto-correct.
+# Configuration parameters: AllowMultipleStyles, EnforcedHashRocketStyle, EnforcedColonStyle, EnforcedLastArgumentHashStyle.
+# SupportedHashRocketStyles: key, separator, table
+# SupportedColonStyles: key, separator, table
+# SupportedLastArgumentHashStyles: always_inspect, always_ignore, ignore_implicit, ignore_explicit
+Layout/AlignHash:
+  Exclude:
+    - 'src/clients/security.rb'
+    - 'src/include/security/dialogs.rb'
+    - 'src/modules/Security.rb'
+
+# Offense count: 1
+# Cop supports --auto-correct.
+Layout/BlockEndNewline:
+  Exclude:
+    - 'src/modules/Security.rb'
+
+# Offense count: 1
+# Cop supports --auto-correct.
+# Configuration parameters: EnforcedStyleAlignWith, AutoCorrect, Severity.
+# SupportedStylesAlignWith: keyword, variable, start_of_line
+Layout/EndAlignment:
+  Exclude:
+    - 'src/modules/Security.rb'
+
+# Offense count: 2
+# Cop supports --auto-correct.
+# Configuration parameters: EnforcedStyle, IndentationWidth.
+# SupportedStyles: consistent, consistent_relative_to_receiver, special_for_inner_method_call, special_for_inner_method_call_in_parentheses
+Layout/IndentFirstArgument:
+  Exclude:
+    - 'src/include/security/dialogs.rb'
+    - 'src/include/security/helps.rb'
+
+# Offense count: 7
+# Cop supports --auto-correct.
+Layout/LeadingCommentSpace:
+  Exclude:
+    - 'src/clients/security.rb'
+    - 'src/include/security/dialogs.rb'
+
+# Offense count: 3
+# Cop supports --auto-correct.
+# Configuration parameters: EnforcedStyle, IndentationWidth.
+# SupportedStyles: aligned, indented
+Layout/MultilineOperationIndentation:
+  Exclude:
+    - 'src/clients/security.rb'
+
+# Offense count: 1
+# Cop supports --auto-correct.
+# Configuration parameters: AllowForAlignment.
+Layout/SpaceAroundOperators:
+  Exclude:
+    - 'test/security_test.rb'
+
+# Offense count: 3
+# Cop supports --auto-correct.
+# Configuration parameters: EnforcedStyle, EnforcedStyleForEmptyBraces, SpaceBeforeBlockParameters.
+# SupportedStyles: space, no_space
+# SupportedStylesForEmptyBraces: space, no_space
+Layout/SpaceInsideBlockBraces:
+  Exclude:
+    - 'src/modules/Security.rb'
+
+# Offense count: 2
+# Cop supports --auto-correct.
+# Configuration parameters: EnforcedStyle, EnforcedStyleForEmptyBraces.
+# SupportedStyles: space, no_space, compact
+# SupportedStylesForEmptyBraces: space, no_space
+Layout/SpaceInsideHashLiteralBraces:
+  Exclude:
+    - 'test/levels_test.rb'
+
+# Offense count: 2
+# Cop supports --auto-correct.
+# Configuration parameters: EnforcedStyle, EnforcedStyleForEmptyBrackets.
+# SupportedStyles: space, no_space
+# SupportedStylesForEmptyBrackets: space, no_space
+Layout/SpaceInsideReferenceBrackets:
+  Exclude:
+    - 'src/include/security/dialogs.rb'
+
+# Offense count: 59
+# Cop supports --auto-correct.
+# Configuration parameters: IndentationWidth.
+Layout/Tab:
+  Exclude:
+    - 'src/clients/security.rb'
+    - 'src/clients/security_auto.rb'
+    - 'src/clients/security_finish.rb'
+    - 'src/clients/security_summary.rb'
+    - 'src/include/security/complex.rb'
+    - 'src/include/security/dialogs.rb'
+    - 'src/include/security/helps.rb'
+    - 'src/include/security/levels.rb'
+    - 'src/include/security/routines.rb'
+    - 'src/include/security/users.rb'
+    - 'src/include/security/widgets.rb'
+    - 'src/include/security/wizards.rb'
+    - 'src/modules/Security.rb'
+
+# Offense count: 7
+# Cop supports --auto-correct.
+# Configuration parameters: AllowInHeredoc.
+Layout/TrailingWhitespace:
+  Exclude:
+    - 'src/clients/security.rb'
+    - 'src/clients/security_auto.rb'
+    - 'src/clients/security_summary.rb'
+    - 'src/include/security/dialogs.rb'
+    - 'src/lib/security/clients/security_finish.rb'
+    - 'test/security_test.rb'
+
+# Offense count: 8
+Lint/LiteralAsCondition:
+  Exclude:
+    - 'src/include/security/complex.rb'
+    - 'src/include/security/dialogs.rb'
+    - 'src/include/security/users.rb'
+    - 'src/include/security/wizards.rb'
+
+# Offense count: 1
+# Cop supports --auto-correct.
+Lint/ScriptPermission:
+  Exclude:
+    - 'test/security_finish_test.rb'
+
+# Offense count: 5
+# Configuration parameters: AllowKeywordBlockArguments.
+Lint/UnderscorePrefixedVariableName:
+  Exclude:
+    - 'src/include/security/complex.rb'
+    - 'src/include/security/routines.rb'
+
+# Offense count: 3
+# Cop supports --auto-correct.
+# Configuration parameters: AllowUnusedKeywordArguments, IgnoreEmptyMethods.
+Lint/UnusedMethodArgument:
+  Exclude:
+    - 'src/include/security/helps.rb'
+    - 'src/include/security/levels.rb'
+    - 'src/include/security/widgets.rb'
+
+# Offense count: 2
+Lint/UselessAssignment:
+  Exclude:
+    - 'src/clients/security.rb'
+    - 'src/include/security/dialogs.rb'
+
+# Offense count: 20
+Metrics/AbcSize:
+  Max: 126
+
+# Offense count: 19
+# Configuration parameters: CountComments, ExcludedMethods.
+# ExcludedMethods: refine
+Metrics/BlockLength:
+  Max: 591
+
+# Offense count: 9
+# Configuration parameters: CountBlocks.
+Metrics/BlockNesting:
+  Max: 6
+
+# Offense count: 1
+# Configuration parameters: CountComments.
+Metrics/ClassLength:
+  Max: 634
+
+# Offense count: 19
+Metrics/CyclomaticComplexity:
+  Max: 34
+
+# Offense count: 41
+# Cop supports --auto-correct.
+# Configuration parameters: AutoCorrect, AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
+# URISchemes: http, https
+Metrics/LineLength:
+  Max: 587
+
+# Offense count: 22
+# Configuration parameters: CountComments, ExcludedMethods.
+Metrics/MethodLength:
+  Max: 259
+
+# Offense count: 7
+# Configuration parameters: CountComments.
+Metrics/ModuleLength:
+  Max: 757
+
+# Offense count: 20
+Metrics/PerceivedComplexity:
+  Max: 39
+
+# Offense count: 2
+# Configuration parameters: ExpectMatchingDefinition, Regex, IgnoreExecutableScripts, AllowedAcronyms.
+# AllowedAcronyms: CLI, DSL, ACL, API, ASCII, CPU, CSS, DNS, EOF, GUID, HTML, HTTP, HTTPS, ID, IP, JSON, LHS, QPS, RAM, RHS, RPC, SLA, SMTP, SQL, SSH, TCP, TLS, TTL, UDP, UI, UID, UUID, URI, URL, UTF8, VM, XML, XMPP, XSRF, XSS
+Naming/FileName:
+  Exclude:
+    - 'src/modules/Security.rb'
+    - 'test/SCRStub.rb'
+
+# Offense count: 38
+# Configuration parameters: EnforcedStyle.
+# SupportedStyles: snake_case, camelCase
+Naming/MethodName:
+  Exclude:
+    - 'src/clients/security.rb'
+    - 'src/include/security/complex.rb'
+    - 'src/include/security/dialogs.rb'
+    - 'src/include/security/routines.rb'
+    - 'src/include/security/users.rb'
+    - 'src/include/security/wizards.rb'
+    - 'src/modules/Security.rb'
+
+# Offense count: 9
+# Configuration parameters: MinNameLength, AllowNamesEndingInNumbers, AllowedNames, ForbiddenNames.
+# AllowedNames: io, id, to, by, on, in, at, ip, db
+Naming/UncommunicativeMethodParamName:
+  Exclude:
+    - 'src/include/security/routines.rb'
+    - 'src/modules/Security.rb'
+
+# Offense count: 29
+# Configuration parameters: EnforcedStyle.
+# SupportedStyles: snake_case, camelCase
+Naming/VariableName:
+  Exclude:
+    - 'src/include/security/complex.rb'
+    - 'src/include/security/dialogs.rb'
+    - 'src/include/security/helps.rb'
+    - 'src/include/security/levels.rb'
+    - 'src/include/security/routines.rb'
+    - 'src/include/security/widgets.rb'
+    - 'src/modules/Security.rb'
+
+# Offense count: 1
+# Cop supports --auto-correct.
+# Configuration parameters: EnforcedStyle, ProceduralMethods, FunctionalMethods, IgnoredMethods, AllowBracesOnProceduralOneLiners.
+# SupportedStyles: line_count_based, semantic, braces_for_chaining, always_braces
+# ProceduralMethods: benchmark, bm, bmbm, create, each_with_object, measure, new, realtime, tap, with_object
+# FunctionalMethods: let, let!, subject, watch
+# IgnoredMethods: lambda, proc, it
+Style/BlockDelimiters:
+  Exclude:
+    - 'src/modules/Security.rb'
+
+# Offense count: 4
+# Cop supports --auto-correct.
+# Configuration parameters: EnforcedStyle, SingleLineConditionsOnly, IncludeTernaryExpressions.
+# SupportedStyles: assign_to_condition, assign_inside_condition
+Style/ConditionalAssignment:
+  Exclude:
+    - 'src/include/security/helps.rb'
+    - 'src/include/security/routines.rb'
+    - 'src/modules/Security.rb'
+
+# Offense count: 1
+# Cop supports --auto-correct.
+Style/Dir:
+  Exclude:
+    - 'test/test_helper.rb'
+
+# Offense count: 16
+Style/Documentation:
+  Exclude:
+    - 'spec/**/*'
+    - 'test/**/*'
+    - 'src/clients/security.rb'
+    - 'src/clients/security_auto.rb'
+    - 'src/clients/security_summary.rb'
+    - 'src/include/security/complex.rb'
+    - 'src/include/security/dialogs.rb'
+    - 'src/include/security/helps.rb'
+    - 'src/include/security/levels.rb'
+    - 'src/include/security/routines.rb'
+    - 'src/include/security/users.rb'
+    - 'src/include/security/widgets.rb'
+    - 'src/include/security/wizards.rb'
+    - 'src/lib/security/clients/security_finish.rb'
+    - 'src/lib/security/ctrl_alt_del_config.rb'
+    - 'src/lib/security/display_manager.rb'
+    - 'src/modules/Security.rb'
+
+# Offense count: 1
+# Cop supports --auto-correct.
+# Configuration parameters: EnforcedStyle.
+# SupportedStyles: empty, nil, both
+Style/EmptyElse:
+  Exclude:
+    - 'src/modules/Security.rb'
+
+# Offense count: 16
+# Cop supports --auto-correct.
+Style/Encoding:
+  Enabled: false
+
+# Offense count: 1
+# Cop supports --auto-correct.
+Style/ExpandPathArguments:
+  Exclude:
+    - 'test/test_helper.rb'
+
+# Offense count: 22
+# Cop supports --auto-correct.
+# Configuration parameters: EnforcedStyle.
+# SupportedStyles: always, never
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+# Offense count: 8
+# Configuration parameters: MinBodyLength.
+Style/GuardClause:
+  Exclude:
+    - 'src/include/security/complex.rb'
+    - 'src/include/security/dialogs.rb'
+    - 'src/include/security/users.rb'
+    - 'src/modules/Security.rb'
+
+# Offense count: 70
+# Cop supports --auto-correct.
+# Configuration parameters: EnforcedStyle, UseHashRocketsWithSymbolValues, PreferHashRocketsForNonAlnumEndingSymbols.
+# SupportedStyles: ruby19, hash_rockets, no_mixed_keys, ruby19_no_mixed_keys
+Style/HashSyntax:
+  Exclude:
+    - 'src/clients/security_auto.rb'
+    - 'src/include/security/routines.rb'
+    - 'src/include/security/wizards.rb'
+    - 'src/modules/Security.rb'
+
+# Offense count: 1
+Style/IfInsideElse:
+  Exclude:
+    - 'src/modules/Security.rb'
+
+# Offense count: 6
+# Cop supports --auto-correct.
+Style/IfUnlessModifier:
+  Exclude:
+    - 'src/include/security/dialogs.rb'
+    - 'src/include/security/routines.rb'
+    - 'src/modules/Security.rb'
+
+# Offense count: 7
+# Cop supports --auto-correct.
+Style/InfiniteLoop:
+  Exclude:
+    - 'src/include/security/dialogs.rb'
+    - 'src/include/security/users.rb'
+    - 'src/include/security/wizards.rb'
+
+# Offense count: 10
+# Cop supports --auto-correct.
+# Configuration parameters: EnforcedStyle.
+# SupportedStyles: line_count_dependent, lambda, literal
+Style/Lambda:
+  Exclude:
+    - 'src/include/security/complex.rb'
+    - 'src/include/security/dialogs.rb'
+    - 'src/include/security/wizards.rb'
+
+# Offense count: 4
+# Cop supports --auto-correct.
+Style/LineEndConcatenation:
+  Exclude:
+    - 'src/include/security/dialogs.rb'
+
+# Offense count: 1
+# Cop supports --auto-correct.
+Style/MultilineIfModifier:
+  Exclude:
+    - 'src/include/security/widgets.rb'
+
+# Offense count: 4
+Style/MultilineTernaryOperator:
+  Exclude:
+    - 'src/include/security/dialogs.rb'
+
+# Offense count: 9
+Style/MultipleComparison:
+  Exclude:
+    - 'src/include/security/complex.rb'
+    - 'src/include/security/dialogs.rb'
+    - 'src/include/security/users.rb'
+    - 'src/include/security/wizards.rb'
+
+# Offense count: 6
+# Cop supports --auto-correct.
+# Configuration parameters: EnforcedStyle.
+# SupportedStyles: literals, strict
+Style/MutableConstant:
+  Exclude:
+    - 'src/include/security/widgets.rb'
+    - 'src/lib/security/ctrl_alt_del_config.rb'
+    - 'src/lib/security/display_manager.rb'
+    - 'src/modules/Security.rb'
+
+# Offense count: 4
+# Cop supports --auto-correct.
+# Configuration parameters: EnforcedStyle.
+# SupportedStyles: predicate, comparison
+Style/NilComparison:
+  Exclude:
+    - 'src/clients/security.rb'
+    - 'src/include/security/routines.rb'
+
+# Offense count: 6
+# Cop supports --auto-correct.
+# Configuration parameters: IncludeSemanticChanges.
+Style/NonNilCheck:
+  Exclude:
+    - 'src/include/security/dialogs.rb'
+    - 'src/include/security/routines.rb'
+    - 'src/modules/Security.rb'
+
+# Offense count: 4
+# Cop supports --auto-correct.
+# Configuration parameters: PreferredDelimiters.
+Style/PercentLiteralDelimiters:
+  Exclude:
+    - 'test/security_test.rb'
+
+# Offense count: 2
+# Cop supports --auto-correct.
+# Configuration parameters: EnforcedStyle.
+# SupportedStyles: short, verbose
+Style/PreferredHashMethods:
+  Exclude:
+    - 'src/include/security/dialogs.rb'
+    - 'test/SCRStub.rb'
+
+# Offense count: 1
+# Cop supports --auto-correct.
+Style/RedundantConditional:
+  Exclude:
+    - 'src/modules/Security.rb'
+
+# Offense count: 2
+# Cop supports --auto-correct.
+Style/RescueModifier:
+  Exclude:
+    - 'src/modules/Security.rb'
+
+# Offense count: 1
+# Cop supports --auto-correct.
+# Configuration parameters: ConvertCodeThatCanStartToReturnNil, Whitelist.
+# Whitelist: present?, blank?, presence, try, try!
+Style/SafeNavigation:
+  Exclude:
+    - 'src/modules/Security.rb'
+
+# Offense count: 3
+# Cop supports --auto-correct.
+# Configuration parameters: EnforcedStyle, ConsistentQuotesInMultiline.
+# SupportedStyles: single_quotes, double_quotes
+Style/StringLiterals:
+  Exclude:
+    - 'src/modules/Security.rb'
+    - 'test/levels_test.rb'
+    - 'test/test_helper.rb'
+
+# Offense count: 2
+# Cop supports --auto-correct.
+# Configuration parameters: EnforcedStyle.
+# SupportedStyles: single_quotes, double_quotes
+Style/StringLiteralsInInterpolation:
+  Exclude:
+    - 'src/modules/Security.rb'
+
+# Offense count: 5
+# Cop supports --auto-correct.
+# Configuration parameters: EnforcedStyle, AllowSafeAssignment.
+# SupportedStyles: require_parentheses, require_no_parentheses, require_parentheses_when_complex
+Style/TernaryParentheses:
+  Exclude:
+    - 'src/include/security/routines.rb'
+    - 'src/modules/Security.rb'
+
+# Offense count: 1
+# Cop supports --auto-correct.
+Style/ZeroLengthPredicate:
+  Exclude:
+    - 'src/modules/Security.rb'

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 require "yast/rake"
 
 Yast::Tasks.configuration do |conf|
-  #lets ignore license check for now
+  # lets ignore license check for now
   conf.skip_license_check << /.*/
 end

--- a/package/yast2-security.changes
+++ b/package/yast2-security.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Jul 28 13:52:52 CEST 2020 - aschnell@suse.com
+
+- Use pam_pwquality instead of pam_cracklib depending on
+  availability (bsc#1171318)
+- Fix setting dictpath for pam_pwquality (bsc#1174619)
+- 4.3.1
+
+-------------------------------------------------------------------
 Tue May 12 15:16:34 UTC 2020 - josef Reidinger <jreidinger@localhost>
 
 - Autoyast schema: Allow optional types for string and map objects

--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-security
-Version:        4.3.0
+Version:        4.3.1
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only
@@ -30,7 +30,8 @@ BuildRequires:  doxygen
 BuildRequires:  pkg-config
 BuildRequires:  perl-XML-Writer
 BuildRequires:  update-desktop-files
-BuildRequires:  yast2-pam
+# Pam.List
+BuildRequires:  yast2-pam >= 4.3.1
 BuildRequires:  yast2-devtools >= 4.2.2
 BuildRequires:  rubygem(%{rb_default_ruby_abi}:yast-rake) >= 0.2.5
 BuildRequires:  rubygem(%{rb_default_ruby_abi}:rspec)
@@ -48,6 +49,8 @@ Requires:       yast2-pam >= 2.14.0
 # CFA::SysctlConfig
 Requires:       yast2 >= 4.2.66
 Requires:       yast2-ruby-bindings >= 1.0.0
+# Pam.List
+Requires:       yast2-pam >= 4.3.1
 
 Provides:       y2c_sec yast2-config-security
 Provides:       yast2-trans-security y2t_sec

--- a/src/autoyast-rnc/security.rnc
+++ b/src/autoyast-rnc/security.rnc
@@ -35,6 +35,7 @@ pass_warn_age = element pass_warn_age { STRING }
 passwd_encryption = element passwd_encryption { STRING }
 passwd_remember_history = element passwd_remember_history { STRING }
 passwd_use_cracklib = element passwd_use_cracklib { STRING }
+passwd_use_pwquality = element passwd_use_pwquality { STRING }
 permission_security = element permission_security { STRING }
 run_updatedb_as = element run_updatedb_as { STRING }
 runlevel3_extra_services = element runlevel3_extra_services { STRING }
@@ -91,6 +92,7 @@ y2_security =
   | pass_min_len
   | pass_warn_age
   | passwd_use_cracklib
+  | passwd_use_pwquality
   | permission_security
   | run_updatedb_as
   | runlevel3_extra_services

--- a/src/clients/security.rb
+++ b/src/clients/security.rb
@@ -50,8 +50,6 @@ module Yast
 
       Yast.include self, "security/wizards.rb"
 
-
-
       # the command line description map
       @cmdline = {
         "id"         => "security",
@@ -142,7 +140,7 @@ module Yast
         "mappings"   => {
           "summary" => [],
           "level"   => ["workstation", "roaming", "server"],
-          #FIXME 1,2,3 aliases
+          #FIXME: 1,2,3 aliases
           "set"     => [
             "passwd",
             "crack",

--- a/src/clients/security.rb
+++ b/src/clients/security.rb
@@ -216,10 +216,10 @@ module Yast
       end
       if Builtins.haskey(options, "crack") &&
           Ops.get_string(options, "crack", "") !=
-            Ops.get(Security.Settings, "PASSWD_USE_CRACKLIB", "")
+            Ops.get(Security.Settings, "PASSWD_USE_PWQUALITY", "")
         Ops.set(
           Security.Settings,
-          "PASSWD_USE_CRACKLIB",
+          "PASSWD_USE_PWQUALITY",
           Ops.get_string(options, "crack", "yes")
         )
         Security.modified = true

--- a/src/data/security/level1.yml
+++ b/src/data/security/level1.yml
@@ -14,7 +14,7 @@ GID_MIN:                          '1000'
 HIBERNATE_SYSTEM:                 active_console
 PASSWD_ENCRYPTION:                sha512
 PASSWD_REMEMBER_HISTORY:          '0'
-PASSWD_USE_CRACKLIB:              'yes'
+PASSWD_USE_PWQUALITY:             'yes'
 PASS_MAX_DAYS:                    '99999'
 PASS_MIN_DAYS:                    '1'
 PASS_MIN_LEN:                     '5'

--- a/src/data/security/level2.yml
+++ b/src/data/security/level2.yml
@@ -14,7 +14,7 @@ GID_MIN:                          '1000'
 HIBERNATE_SYSTEM:                 active_console
 PASSWD_ENCRYPTION:                sha512
 PASSWD_REMEMBER_HISTORY:          '0'
-PASSWD_USE_CRACKLIB:              'yes'
+PASSWD_USE_PWQUALITY:             'yes'
 PASS_MAX_DAYS:                    '99999'
 PASS_MIN_DAYS:                    '1'
 PASS_MIN_LEN:                     '5'

--- a/src/data/security/level3.yml
+++ b/src/data/security/level3.yml
@@ -14,7 +14,7 @@ GID_MIN:                          '1000'
 HIBERNATE_SYSTEM:                 active_console
 PASSWD_ENCRYPTION:                sha512
 PASSWD_REMEMBER_HISTORY:          '0'
-PASSWD_USE_CRACKLIB:              'yes'
+PASSWD_USE_PWQUALITY:             'yes'
 PASS_MAX_DAYS:                    '99999'
 PASS_MIN_DAYS:                    '1'
 PASS_MIN_LEN:                     '6'

--- a/src/include/security/dialogs.rb
+++ b/src/include/security/dialogs.rb
@@ -747,7 +747,7 @@ module Yast
           0.15,
           _("Checks"),
           VBox(
-            settings2widget("PASSWD_USE_CRACKLIB"),
+            settings2widget("PASSWD_USE_PWQUALITY"),
             VSeparator(),
             settings2widget("PASS_MIN_LEN"),
             VSeparator(),
@@ -800,7 +800,7 @@ module Yast
       UI.ChangeWidget(
         Id("PASS_MIN_LEN"),
         :Enabled,
-        Ops.get(Security.Settings, "PASSWD_USE_CRACKLIB", "") == "yes"
+        Ops.get(Security.Settings, "PASSWD_USE_PWQUALITY", "") == "yes"
       )
 
       ret = nil
@@ -816,8 +816,8 @@ module Yast
           end
         elsif ret == :back
           break
-        elsif ret == "PASSWD_USE_CRACKLIB"
-          # minlen is an option for pam_cracklib
+        elsif ret == "PASSWD_USE_PWQUALITY"
+          # minlen is an option for pam_pwquality
           UI.ChangeWidget(
             Id("PASS_MIN_LEN"),
             :Enabled,
@@ -874,7 +874,7 @@ module Yast
         widget2settings("PASS_MIN_DAYS")
         widget2settings("PASS_MAX_DAYS")
         widget2settings("PASS_MIN_LEN")
-        widget2settings("PASSWD_USE_CRACKLIB")
+        widget2settings("PASSWD_USE_PWQUALITY")
         widget2settings("PASS_WARN_AGE")
         widget2settings("PASSWD_ENCRYPTION")
         widget2settings("PASSWD_REMEMBER_HISTORY")

--- a/src/include/security/dialogs.rb
+++ b/src/include/security/dialogs.rb
@@ -167,7 +167,6 @@ module Yast
       ret
     end
 
-
     def OverviewText(type)
       ret = ""
       ret_table = []
@@ -319,7 +318,6 @@ module Yast
         end
       end 
 
-
       if type == :table
         Builtins.y2debug("Overview table: %1", ret_table)
         return deep_copy(ret_table)
@@ -357,7 +355,6 @@ module Yast
             group = Builtins.mergestring(l, _(" or "))
             srvs = Ops.add(Ops.add(srvs, group), "<BR>")
           end
-
 
           # richtext message: %1 = runlevel ("3" or "5"), %2 = list of services
           help +=

--- a/src/include/security/helps.rb
+++ b/src/include/security/helps.rb
@@ -334,7 +334,6 @@ module Yast
           "<P>Every running service is a potential target of a security attack. Therefore it is recommended to turn off all services which are not used by the system.</P>"
         )
       }
-
     end
 
     def boot_dialog_help

--- a/src/include/security/levels.rb
+++ b/src/include/security/levels.rb
@@ -71,6 +71,7 @@ module Yast
       @Levels = @LevelsNames.keys.each_with_object({}) do |level, levels|
         lfile = Directory.find_data_file("security/#{level.downcase}.yml")
         raise(Errno::ENOENT, "#{level.downcase}.yml file not found") unless lfile
+
         levels[level] = YAML.load_file(lfile)
       end
 

--- a/src/include/security/widgets.rb
+++ b/src/include/security/widgets.rb
@@ -186,7 +186,7 @@ module Yast
             "Value"   => "des",
             "Notify"  => "yes"
           },
-          "PASSWD_USE_CRACKLIB"          => {
+          "PASSWD_USE_PWQUALITY"         => {
             "Widget" => "CheckBox",
             # CheckBox label
             "Label"  => _("&Check New Passwords"),

--- a/src/lib/security/ctrl_alt_del_config.rb
+++ b/src/lib/security/ctrl_alt_del_config.rb
@@ -56,6 +56,7 @@ module Security
       def current
         return current_systemd if systemd?
         return current_inittab if inittab?
+
         nil
       end
 

--- a/src/lib/security/display_manager.rb
+++ b/src/lib/security/display_manager.rb
@@ -37,7 +37,6 @@ module Security
     private_class_method :new
     attr_reader :name
 
-
     def self.current
       configured_dm = Yast::SCR.Read(Yast::Path.new(CONFIG_PATH)).to_s
       configured_dm.empty? ? nil : new(configured_dm)

--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -126,7 +126,7 @@ module Yast
         "GID_MIN"                                   => "1000",
         "HIBERNATE_SYSTEM"                          => "active_console",
         "PASSWD_ENCRYPTION"                         => "sha512",
-        "PASSWD_USE_CRACKLIB"                       => "yes",
+        "PASSWD_USE_PWQUALITY"                      => "yes",
         "PASS_MAX_DAYS"                             => "99999",
         "PASS_MIN_DAYS"                             => "0",
         "PASS_MIN_LEN"                              => "5",
@@ -195,7 +195,7 @@ module Yast
       }
 
       # Mapping of /etc/sysctl.conf keys to old (obsoleted) sysconfig ones
-      # (used during autoYaST import
+      # (used during autoYaST import)
       @sysctl2sysconfig = {
         "kernel.sysrq"                 => "ENABLE_SYSRQ",
         "net.ipv4.tcp_syncookies"      => "IP_TCP_SYNCOOKIES",
@@ -382,15 +382,15 @@ module Yast
     def read_pam_settings
       read_encryption_method
 
-      # cracklib and pwhistory settings (default values)
+      # pwquality and pwhistory settings (default values)
       @Settings["PASS_MIN_LEN"] = "5"
       @Settings["PASSWD_REMEMBER_HISTORY"] = "0"
       @Settings["CRACKLIB_DICT_PATH"] = "/usr/lib/cracklib_dict"
 
-      pam_cracklib = Pam.Query("cracklib") || {}
-      @Settings["PASSWD_USE_CRACKLIB"] = pam_cracklib.size > 0 ? "yes" : "no"
+      pam_pwquality = Pam.Query(pwquality_module) || {}
+      @Settings["PASSWD_USE_PWQUALITY"] = pam_pwquality.size > 0 ? "yes" : "no"
 
-      pam_cracklib.fetch("password", []).each do |entry|
+      pam_pwquality.fetch("password", []).each do |entry|
         key,value = entry.split("=")
         if value
           @Settings["CRACKLIB_DICT_PATH"] = value if key == "dictpath"
@@ -438,6 +438,17 @@ module Yast
                                       end
       log.debug "HIBERNATE_SYSTEM (after #{__callee__}): " \
         "#{@Settings['HIBERNATE_SYSTEM']}"
+    end
+
+    # The name of the PAM module to deal with password quality. Either
+    # "pwquality" or "cracklib". See bug #1171318 why this is needed.
+    def pwquality_module
+      return @mod_name if @mod_name
+
+      # Both pwquality and cracklib can be installed. in that case
+      # cracklib seems to be a non-functional deprecated module. So
+      # prefer pwquality.
+      @mod_name = Pam.List.include?("pwquality") ? "pwquality" : "cracklib"
     end
 
     # Read all security settings
@@ -545,24 +556,24 @@ module Yast
 
     # Write settings related to PAM behavior
     def write_pam_settings
-      # use cracklib?
-      if @Settings["PASSWD_USE_CRACKLIB"] == "yes"
-        Pam.Add("cracklib")
+      # use pwquality?
+      if @Settings["PASSWD_USE_PWQUALITY"] == "yes"
+        Pam.Add(pwquality_module)
         pth = @Settings["CRACKLIB_DICT_PATH"]
         if pth && pth != "/usr/lib/cracklib_dict"
-          Pam.Add("--cracklib-dictpath=#{pth}")
+          Pam.Add(pwquality_module + "-dictpath=#{pth}")
         end
       else
-        Pam.Remove("cracklib")
+        Pam.Remove(pwquality_module)
       end
 
       # save min pass length
       min_len = @Settings["PASS_MIN_LEN"]
-      if min_len && min_len != "5" && @Settings["PASSWD_USE_CRACKLIB"] == "yes"
-        Pam.Add("cracklib") # minlen is part of cracklib
-        Pam.Add("cracklib-minlen=#{min_len}")
+      if min_len && min_len != "5" && @Settings["PASSWD_USE_PWQUALITY"] == "yes"
+        Pam.Add(pwquality_module) # minlen is part of pwquality
+        Pam.Add(pwquality_module + "-minlen=#{min_len}")
       else
-        Pam.Remove("cracklib-minlen")
+        Pam.Remove(pwquality_module + "-minlen")
       end
 
       # save "remember" value (number of old user passwords to not allow)
@@ -753,6 +764,10 @@ module Yast
         end
       end
 
+      if settings.key?("PASSWD_USE_CRACKLIB")
+        settings["PASSWD_USE_PWQUALITY"] = settings.delete("PASSWD_USE_CRACKLIB")
+      end
+
       return true if settings == {}
 
       @modified = true
@@ -784,6 +799,10 @@ module Yast
         if [TrueClass, FalseClass].include?(settings[key].class)
           settings[key] = settings[key] ? "1" : "0"
         end
+      end
+
+      if pwquality_module == "cracklib"
+        settings["PASSWD_USE_CRACKLIB"] = settings.delete("PASSWD_USE_PWQUALITY")
       end
 
       settings

--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -64,7 +64,6 @@ module Yast
       "USERDEL_POSTCMD"
     ].freeze
 
-
     attr_reader :display_manager
 
     def main
@@ -87,7 +86,6 @@ module Yast
     end
 
     def init_settings
-
       # Services to check
       srv_file = Directory.find_data_file("security/services.yml")
       if srv_file
@@ -280,6 +278,7 @@ module Yast
     # @return blah blah lahjk
     def Abort
       return Builtins.eval(@AbortFunction) == true if @AbortFunction != nil
+
       false
     end
 
@@ -323,7 +322,7 @@ module Yast
     # Read the information about ctrl+alt+del behavior
     # See bug 742783 for description
     def ReadConsoleShutdown
-     @Settings["CONSOLE_SHUTDOWN"] = ::Security::CtrlAltDelConfig.current || ::Security::CtrlAltDelConfig.default   
+      @Settings["CONSOLE_SHUTDOWN"] = ::Security::CtrlAltDelConfig.current || ::Security::CtrlAltDelConfig.default
     end
 
     # Read the settings from the files included in @Locations
@@ -391,7 +390,7 @@ module Yast
       @Settings["PASSWD_USE_PWQUALITY"] = pam_pwquality.size > 0 ? "yes" : "no"
 
       pam_pwquality.fetch("password", []).each do |entry|
-        key,value = entry.split("=")
+        key, value = entry.split("=")
         if value
           @Settings["CRACKLIB_DICT_PATH"] = value if key == "dictpath"
           @Settings["PASS_MIN_LEN"]       = value if key == "minlen"
@@ -400,7 +399,7 @@ module Yast
 
       pam_history = Pam.Query("pwhistory") || {}
       pam_history.fetch("password", []).each do |entry|
-        key,value = entry.split("=")
+        key, value = entry.split("=")
         if key == "remember" && value
           @Settings["PASSWD_REMEMBER_HISTORY"] = value
         end
@@ -653,6 +652,7 @@ module Yast
       # NOTE: the call to #sort is only needed to satisfy the old testsuite
       @activation_mapping.sort.each do |setting, action|
         next if @Settings[setting] == @Settings_bak[setting]
+
         log.info(
           "Option #{setting} has been modified, "\
           "activating the change: #{action}"
@@ -666,6 +666,7 @@ module Yast
     # @return true on success
     def Write
       return true if !@modified
+
       log.info "Writing configuration"
 
       # Security read dialog caption
@@ -705,6 +706,7 @@ module Yast
 
       # Write security settings
       return false if Abort()
+
       Progress.NextStage
       if !@Settings["PERMISSION_SECURITY"].include?("local")
         @Settings["PERMISSION_SECURITY"] << " local"
@@ -714,11 +716,13 @@ module Yast
 
       # Write inittab settings
       return false if Abort()
+
       Progress.NextStage
       write_console_shutdown(@Settings.fetch("CONSOLE_SHUTDOWN", "ignore"))
 
       # Write authentication and privileges settings
       return false if Abort()
+
       Progress.NextStage
       write_pam_settings
       write_polkit_settings
@@ -726,14 +730,17 @@ module Yast
 
       # Finish him
       return false if Abort()
+
       Progress.NextStage
       apply_new_settings(sysctl: sysctl_modified)
 
       return false if Abort()
+
       Progress.NextStage
       activate_changes
 
       return false if Abort()
+
       @modified = false
       true
     end
@@ -916,6 +923,7 @@ module Yast
     # @return [Yast2::CFA::SysctlConfig]
     def sysctl_config
       return @sysctl_config if @sysctl_config
+
       @sysctl_config = CFA::SysctlConfig.new
       @sysctl_config.load
       @sysctl_config

--- a/test/levels_test.rb
+++ b/test/levels_test.rb
@@ -60,9 +60,10 @@ module Yast
       let(:empty_bash_output) { {"exit" => 0, "stdout" => "", "stderr" => ""} }
 
       it "defines the system behavior" do
-        expect(SCR).to exec_bash_output("/usr/sbin/pam-config -a --cracklib")
+        allow(Pam).to receive(:List).and_return(["pwquality", "pwhistory"])
+        expect(SCR).to exec_bash_output("/usr/sbin/pam-config -a --pwquality")
           .and_return(empty_bash_output)
-        expect(SCR).to exec_bash_output("/usr/sbin/pam-config -d --cracklib-minlen")
+        expect(SCR).to exec_bash_output("/usr/sbin/pam-config -d --pwquality-minlen")
           .and_return(empty_bash_output)
         expect(SCR).to exec_bash_output("/usr/sbin/pam-config -d --pwhistory-remember")
           .and_return(empty_bash_output)

--- a/test/security_test.rb
+++ b/test/security_test.rb
@@ -739,7 +739,7 @@ module Yast
     describe "#Import" do
       before do
         # GENERAL
-        Security.Settings["FAIL_DELAY"]       = "5"
+        Security.Settings["FAIL_DELAY"]         = "5"
         Security.Settings["PASS_MIN_LEN"]       = "3"
         Security.Settings["MANDATORY_SERVICES"] = "no"
 

--- a/test/security_test.rb
+++ b/test/security_test.rb
@@ -533,19 +533,19 @@ module Yast
         Security.read_pam_settings
       end
 
-      it "sets cracklib settings" do
+      it "sets pwquality settings" do
         allow(Pam).to receive(:Query).with("pwhistory")
-        allow(Pam).to receive(:Query).with("cracklib")
+        allow(Pam).to receive(:Query).with("pwquality")
           .and_return("password" => ["dictpath=/shared/cracklib_dict", "minlen="])
 
         Security.read_pam_settings
-        expect(Security.Settings["PASSWD_USE_CRACKLIB"]).to eql("yes")
+        expect(Security.Settings["PASSWD_USE_PWQUALITY"]).to eql("yes")
         expect(Security.Settings["CRACKLIB_DICT_PATH"]).to eql("/shared/cracklib_dict")
         expect(Security.Settings["PASS_MIN_LEN"]).to eql("5")
       end
 
       it "sets password remember history settings" do
-        allow(Pam).to receive(:Query).with("cracklib")
+        allow(Pam).to receive(:Query).with("pwquality")
         allow(Pam).to receive(:Query).with("pwhistory")
           .and_return("password" => ["remember=5"])
 


### PR DESCRIPTION
The PR makes YaST select between pam_pwquality and pam_cracklib depending on availability.

For https://trello.com/c/ahoBngck/1948-5-ostumbleweed-p5-1171318-build-20200506-yast-security-module-integrate-with-pampwdquality and https://bugzilla.suse.com/show_bug.cgi?id=1171318. Also fixes https://bugzilla.suse.com/show_bug.cgi?id=1174619.