### PR TITLE
Fixed randomly failing unit tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -178,6 +178,8 @@ Metrics/AbcSize:
 # ExcludedMethods: refine
 Metrics/BlockLength:
   Max: 591
+  Exclude:
+    - 'test/**/*.rb'
 
 # Offense count: 9
 # Configuration parameters: CountBlocks.

--- a/package/yast2-security.changes
+++ b/package/yast2-security.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Aug 13 10:00:58 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed randomly failing unit tests, do not query the installed
+  PAM modules in the testing system (related to bsc#1171318)
+- 4.3.3
+
+-------------------------------------------------------------------
 Mon Aug 10 17:40:01 CEST 2020 - schubi@suse.de
 
 - AutoYaST: Added supplements: autoyast(security) into the spec file

--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-security
-Version:        4.3.2
+Version:        4.3.3
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/test/security_test.rb
+++ b/test/security_test.rb
@@ -520,6 +520,7 @@ module Yast
     describe "#read_pam_settings" do
       before do
         change_scr_root(File.join(DATA_PATH, "system"))
+        allow(Pam).to receive(:List).and_return(["pwquality"])
       end
 
       after do


### PR DESCRIPTION
- Added a missing mock, do not query the installed PAM modules in the testing system