### PR TITLE
set cracklib dictpath correctly (bsc#1174619)

### DIFF
--- a/package/yast2-security.changes
+++ b/package/yast2-security.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Aug 25 10:37:12 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
+
+- set cracklib dictpath correctly (bsc#1174619)
+- 4.2.13
+
+-------------------------------------------------------------------
 Tue Mar 31 17:41:17 UTC 2020 - Knut Anderssen <kanderssen@suse.com>
 
 - Apply sysctl changes to the running system when the YaST sysctl

--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-security
-Version:        4.2.12
+Version:        4.2.13
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -550,7 +550,7 @@ module Yast
         Pam.Add("cracklib")
         pth = @Settings["CRACKLIB_DICT_PATH"]
         if pth && pth != "/usr/lib/cracklib_dict"
-          Pam.Add("--cracklib-dictpath=#{pth}")
+          Pam.Add("cracklib-dictpath=#{pth}")
         end
       else
         Pam.Remove("cracklib")


### PR DESCRIPTION
## Task

- https://bugzilla.suse.com/show_bug.cgi?id=1174619
- https://trello.com/c/AppUwK8q

Pass `--cracklib-dictpath` option to PAM in the correct way.

## See also

This has been fixed in `master` branch as part of https://github.com/yast/yast-security/pull/70.