### PR TITLE
Translate <enable_sysrq> to <kernel.sysrq> with the correct value

### DIFF
--- a/package/yast2-security.changes
+++ b/package/yast2-security.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Oct 27 13:26:57 CET 2020 - schubi@suse.de
+
+- AY-Import: Translate <enable_sysrq> setting to <kernel.sysrq>
+  with the correct value format (bsc#1177720).
+- 4.2.14
+
+-------------------------------------------------------------------
 Tue Aug 25 10:37:12 UTC 2020 - Steffen Winterfeldt <snwint@suse.com>
 
 - set cracklib dictpath correctly (bsc#1174619)

--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-security
-Version:        4.2.13
+Version:        4.2.14
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -41,9 +41,13 @@ module Yast
     include Yast::Logger
     include ::Security::CtrlAltDelConfig
 
-    SYSCTL_VALUES = {
+    SYSCTL_VALUES_TO_BOOLEAN = {
       "yes" => true,
       "no"  => false
+    }
+    SYSCTL_VALUES_TO_INTSTRING = {
+      "yes" => "1",
+      "no"  => "0"
     }
 
     SHADOW_ATTRS = [
@@ -762,9 +766,15 @@ module Yast
           tmpSettings[k] = settings[k]
         else
           if @sysctl.key?(k) && settings.key?(@sysctl2sysconfig[k])
+            # using the old sysconfig AY format
             val = settings[@sysctl2sysconfig[k]].to_s
-            tmpSettings[k] = SYSCTL_VALUES.key?(val) ? SYSCTL_VALUES[val] : val
+            if @sysctl[k].is_a?(TrueClass) || @sysctl[k].is_a?(FalseClass)
+              tmpSettings[k] = SYSCTL_VALUES_TO_BOOLEAN.key?(val) ? SYSCTL_VALUES_TO_BOOLEAN[val] : val
+            else
+              tmpSettings[k] = SYSCTL_VALUES_TO_INTSTRING.key?(val) ? SYSCTL_VALUES_TO_INTSTRING[val] : val
+            end
           else
+            # using old login defs settings ?
             tmpSettings[k] = settings[@obsolete_login_defs[k]] || v
           end
         end

--- a/test/security_test.rb
+++ b/test/security_test.rb
@@ -781,6 +781,12 @@ module Yast
           expect(Security.Settings["SYS_GID_MIN"]).to eql("150")
         end
 
+        it "imports enable_sysrq settings transforming key name" do
+          expect(Security.Import("enable_sysrq" => "no")).to eql(true)
+
+          expect(Security.Settings["kernel.sysrq"]).to eql("0")
+        end
+
         it "does not modify not given settings" do
           expect(Security.Import("EXTRA_SERVICES" => "yes")).to eql(true)
 


### PR DESCRIPTION
AY-Import: Translate <enable_sysrq> setting to <kernel.sysrq> with the correct value format (bsc#1177720).