### PR TITLE
Removed obsolete setting DISPLAYMANAGER_SHUTDOWN

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -210,7 +210,7 @@ Metrics/MethodLength:
 # Offense count: 7
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
-  Max: 757
+  Max: 760
 
 # Offense count: 20
 Metrics/PerceivedComplexity:

--- a/package/yast2-security.changes
+++ b/package/yast2-security.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Dec 14 14:49:26 UTC 2020 - schubi <schubi@intern>
+
+- Removed obsolete setting DISPLAYMANAGER_SHUTDOWN from
+  /etc/sysconfig/displaymanager (bsc#1175495).
+- 4.3.6 
+
+-------------------------------------------------------------------
 Fri Dec 11 11:24:05 UTC 2020 - schubi <schubi@localhost>
 
 - Removed handling of obsolete entry SYSTOHC in /etc/sysconfig/clock

--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-security
-Version:        4.3.5
+Version:        4.3.6
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/include/security/dialogs.rb
+++ b/src/include/security/dialogs.rb
@@ -550,11 +550,18 @@ module Yast
     end
 
     def vbox_boot_permissions
+      display_manager_widget = Empty()
+      if @display_manager && !@display_manager.shutdown_var_name.empty?
+        display_manager_widget = VBox(
+          VSpacing(1.0),
+          settings2widget(@display_manager.shutdown_var_name)
+        )
+      end
+
       VBox(
         VSpacing(1),
         settings2widget("CONSOLE_SHUTDOWN"),
-        @display_manager ? VSpacing(1.0) : Empty(),
-        @display_manager ? settings2widget(@display_manager.shutdown_var_name) : Empty(),
+        display_manager_widget,
         VSpacing(1.0),
         settings2widget("HIBERNATE_SYSTEM"),
         VSpacing(1)
@@ -635,7 +642,9 @@ module Yast
 
       if ret == :next || Builtins.contains(@tree_dialogs, ret)
         widget2settings("CONSOLE_SHUTDOWN")
-        widget2settings(@display_manager.shutdown_var_name) if @display_manager
+        if @display_manager && !@display_manager.shutdown_var_name.empty?
+          widget2settings(@display_manager.shutdown_var_name)
+        end
         widget2settings("HIBERNATE_SYSTEM")
       end
 

--- a/src/include/security/widgets.rb
+++ b/src/include/security/widgets.rb
@@ -265,7 +265,7 @@ module Yast
 
       @WIDGETS.merge!(
         @display_manager.shutdown_var_name => shutdown_login_manager_widget
-      ) if @display_manager
+      ) if @display_manager && !@display_manager.shutdown_var_name.empty?
     end
 
     def shutdown_login_manager_widget

--- a/src/lib/security/display_manager.rb
+++ b/src/lib/security/display_manager.rb
@@ -51,27 +51,23 @@ module Security
     end
 
     def default_settings
-      { shutdown_var_name => shutdown_default_value }
+      kdm? ? { "AllowShutdown" => "All" } : {}
     end
 
     def shutdown_var_name
-      @shutdown_var_name ||= kdm? ? "AllowShutdown" : "DISPLAYMANAGER_SHUTDOWN"
+      @shutdown_var_name ||= kdm? ? "AllowShutdown" : ""
     end
 
     def shutdown_default_value
-      @shutdown_default_value ||= kdm? ? "All" : "all"
+      @shutdown_default_value ||= kdm? ? "All" : ""
     end
 
     def shutdown_options
-      @shutdown_options ||= kdm? ? ["Root", "All", "None"] : ["root", "all", "none"]
+      @shutdown_options ||= kdm? ? ["Root", "All", "None"] : []
     end
 
     def default_locations
-      sysconfig_locations = SYSCONFIG_COMMON_LOCATIONS
-      sysconfig_locations << shutdown_var_name if !kdm?
-
-      locations = { ".sysconfig.displaymanager" => sysconfig_locations }
-
+      locations = { ".sysconfig.displaymanager" => SYSCONFIG_COMMON_LOCATIONS }
       locations[".kde4.kdmrc"] = ["AllowShutdown"] if kdm?
 
       locations

--- a/test/security_test.rb
+++ b/test/security_test.rb
@@ -661,10 +661,6 @@ module Yast
           Security.init_settings
         end
 
-        it "allows everybody to shutdown by default" do
-          expect(Security.Settings["DISPLAYMANAGER_SHUTDOWN"]).to eql("all")
-        end
-
         it "sets login definitions based on /etc/login.defs" do
           Security.read_from_locations
           expect(Security.Settings["FAIL_DELAY"]).to eql("3")
@@ -675,7 +671,6 @@ module Yast
           expect(Security.Settings["DISPLAYMANAGER_REMOTE_ACCESS"]).to eql("yes")
           expect(Security.Settings["DISPLAYMANAGER_ROOT_LOGIN_REMOTE"]).to eql("yes")
           expect(Security.Settings["DISPLAYMANAGER_XSERVER_TCP_PORT_6000_OPEN"]).to eql("no")
-          expect(Security.Settings["DISPLAYMANAGER_SHUTDOWN"]).to eql("all")
           expect(Security.Settings["PERMISSION_SECURITY"]).to eql("easy local")
           expect(Security.Settings["DISABLE_RESTART_ON_UPDATE"]).to eql("no")
         end


### PR DESCRIPTION
Removed obsolete setting DISPLAYMANAGER_SHUTDOWN from /etc/sysconfig/displaymanager (bsc#1175495).