### PR TITLE
Update spec files with new requirement

### DIFF
--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -32,6 +32,8 @@ BuildRequires:  perl-XML-Writer
 BuildRequires:  update-desktop-files
 BuildRequires:  yast2-pam
 BuildRequires:  yast2-devtools >= 4.2.2
+# Y2Security::SelinuxConfig requires Yast::Bootloader
+BuildRequires:  yast2-bootloader
 BuildRequires:  rubygem(%{rb_default_ruby_abi}:yast-rake) >= 0.2.5
 BuildRequires:  rubygem(%{rb_default_ruby_abi}:rspec)
 # CFA::SysctlConfig
@@ -48,6 +50,8 @@ Requires:       yast2-pam >= 2.14.0
 # CFA::SysctlConfig
 Requires:       yast2 >= 4.2.66
 Requires:       yast2-ruby-bindings >= 1.0.0
+# Y2Security::SelinuxConfig requires Yast::Bootloader
+BuildRequires:  yast2-bootloader
 
 Provides:       y2c_sec yast2-config-security
 Provides:       yast2-trans-security y2t_sec


### PR DESCRIPTION
`Y2Security::SelinuxConfig` added in #83  makes use of Yast::Bootloader.