### PR TITLE
AutoYaST for SELinux

### DIFF
--- a/package/yast2-security.changes
+++ b/package/yast2-security.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Sun Feb 14 21:13:17 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- AutoYaST: add support for SELinux configuration (jsc#SMO-20,
+  jsc#SLE-17342).
+- 4.2.18
+
+-------------------------------------------------------------------
 Fri Feb 12 09:12:11 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
 - Avoid crashing when the SELinux configuration file does not

--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-security
-Version:        4.2.17
+Version:        4.2.18
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/autoyast-rnc/security.rnc
+++ b/src/autoyast-rnc/security.rnc
@@ -7,6 +7,7 @@ cwd_in_user_path = element cwd_in_user_path { text }
 disable_restart_on_update = element disable_restart_on_update { text }
 disable_stop_on_removal = element disable_stop_on_removal { text }
 extra_services = element extra_services { text }
+selinux_mode = element selinux_mode { text }
 displaymanager_remote_access = element displaymanager_remote_access { text }
 displaymanager_root_login_remote = element displaymanager_root_login_remote { text }
 displaymanager_shutdown = element displaymanager_shutdown { text }
@@ -69,6 +70,7 @@ y2_security =
   | disable_restart_on_update
   | disable_stop_on_removal
   | extra_services
+  | selinux_mode
   | displaymanager_remote_access
   | displaymanager_root_login_remote
   | displaymanager_xserver_tcp_port_6000_open

--- a/src/clients/security_auto.rb
+++ b/src/clients/security_auto.rb
@@ -30,14 +30,13 @@
 # goes through the configuration and return the setting.
 # Does not do any changes to the configuration.
 
+require "y2security/selinux_config"
+
 # @param function to execute
 # @param map/list of security settings
 # @return [Hash] edited settings, Summary or boolean on success depending on called function
 # @example map mm = $[ "FAIL_DELAY" : "77" ];
 # @example map ret = WFM::CallFunction ("security_auto", [ "Summary", mm ]);
-
-require "y2security/selinux_config"
-
 module Yast
   class SecurityAutoClient < Client
     def main

--- a/src/clients/security_auto.rb
+++ b/src/clients/security_auto.rb
@@ -30,7 +30,7 @@
 # goes through the configuration and return the setting.
 # Does not do any changes to the configuration.
 
-require "y2security/selinux_config"
+require "y2security/selinux"
 
 # @param function to execute
 # @param map/list of security settings
@@ -86,7 +86,7 @@ module Yast
 
         #Checking value semantic
         if @param.has_key?("selinux_mode")
-          selinux_values = Y2Security::SelinuxConfig.new.modes.map {|m| m.id.to_s}
+          selinux_values = Y2Security::Selinux.new.modes.map {|m| m.id.to_s}
           if !selinux_values.include?(@param["selinux_mode"])
             Yast::AutoInstall.issues_list.add(
               :invalid_value,

--- a/src/lib/y2security/selinux.rb
+++ b/src/lib/y2security/selinux.rb
@@ -185,8 +185,15 @@ module Y2Security
     #                   false if running in installation where selinux is not configurable;
     #                   the Yast::Bootloader#Write return value otherwise
     def save
-      return false unless configurable?
+      unless configurable?
+        log.warn("Do NOT set Mode to: #{mode.id}")
+        log.info("With bootloader kernel params: #{mode.options}")
+        log.warn("Because it has NOT been enabled in the product control file.")
+        return false
+      end
 
+      log.info("Set Mode to: #{mode.id}")
+      log.info("With bootloader kernel params: #{mode.options}")
       Yast::Bootloader.modify_kernel_params(mode.options)
       config_file.selinux = mode.id.to_s
       config_file.save

--- a/src/lib/y2security/selinux.rb
+++ b/src/lib/y2security/selinux.rb
@@ -185,15 +185,8 @@ module Y2Security
     #                   false if running in installation where selinux is not configurable;
     #                   the Yast::Bootloader#Write return value otherwise
     def save
-      unless configurable?
-        log.warn("Do NOT set Mode to: #{mode.id}")
-        log.info("With bootloader kernel params: #{mode.options}")
-        log.warn("Because it has NOT been enabled in the product control file.")
-        return false
-      end
+      return false unless configurable?
 
-      log.info("Set Mode to: #{mode.id}")
-      log.info("With bootloader kernel params: #{mode.options}")
       Yast::Bootloader.modify_kernel_params(mode.options)
       config_file.selinux = mode.id.to_s
       config_file.save

--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -567,7 +567,7 @@ module Yast
     #
     # @return true on success
     def write_selinux
-      return if @Settings["SELINUX_MODE"].empty?
+      return if @Settings["SELINUX_MODE"].to_s.empty?
 
       selinux_config.mode = @Settings["SELINUX_MODE"]
 

--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -449,7 +449,8 @@ module Yast
     end
 
     def read_selinux_settings
-      current_mode = Y2Security::Selinux.new.running_mode.id.to_s
+      current_mode = Y2Security::Selinux.new.mode.id.to_s
+
       if current_mode != "disabled"
         @Settings["SELINUX_MODE"] = current_mode
       else

--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -566,18 +566,8 @@ module Yast
     #
     # @return true on success
     def write_selinux
-      return if @Settings["SELINUX_MODE"].to_s.empty?
-
       selinux_config.mode = @Settings["SELINUX_MODE"]
-
-      # Y2Security::Selinux.mode= fallbacks to the "Disabled" mode when wrong value is given.
-      # In consequence, let's check that the mode still being the same before saving it.
-      if selinux_config.mode.id.to_s != @Settings["SELINUX_MODE"]
-        log.info("The set SELinux mode does not match with the requested one. Not saving it.")
-        false
-      else
-        selinux_config.save
-      end
+      selinux_config.save
     end
 
 

--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -899,15 +899,11 @@ module Yast
 
     protected
 
-    # Ensures needed patterns for SELinux will be installed
+    # Ensures needed patterns for SELinux, if any, will be installed
     def set_selinux_patterns
-      return if @Settings["SELINUX_MODE"].to_s.empty?
+      selinux_config.mode = @Settings["SELINUX_MODE"] unless @Settings["SELINUX_MODE"].to_s.empty?
 
-      patterns = selinux_config.needed_patterns
-
-      return if patterns.empty?
-
-      PackagesProposal.SetResolvables("selinux_patterns", :pattern, patterns)
+      PackagesProposal.SetResolvables("selinux_patterns", :pattern, selinux_config.needed_patterns)
     end
 
     # Sets @missing_mandatory_services honoring the systemd aliases

--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -449,16 +449,13 @@ module Yast
     end
 
     def read_selinux_settings
-      current_mode = Y2Security::Selinux.new.mode.id.to_s
+      @Settings.delete("SELINUX_MODE")
 
-      if current_mode != "disabled"
-        @Settings["SELINUX_MODE"] = current_mode
-      else
-        @Settings.delete("SELINUX_MODE") if @Settings.has_key?("SELINUX_MODE")
+      if selinux_config.mode.id != :disabled
+        @Settings["SELINUX_MODE"] = selinux_config.mode.id.to_s
       end
 
-      log.debug "SELINUX_MODE (after #{__callee__}): " \
-        "#{@Settings['SELINUX_MODE']}"
+      log.debug "SELINUX_MODE (after #{__callee__}): #{@Settings['SELINUX_MODE']}"
     end
 
     # Read all security settings

--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -565,6 +565,15 @@ module Yast
       shadow_config.save
     end
 
+    # Set SELinux settings
+    # @return true on success
+    def write_selinux
+      return if !@Settings["SELINUX_MODE"] || @Settings["SELINUX_MODE"].empty?
+      selinux = Y2Security::SelinuxConfig.new
+      selinux.mode = @Settings["SELINUX_MODE"]
+      selinux.save
+    end
+
     # Write settings related to PAM behavior
     def write_pam_settings
       # use cracklib?
@@ -892,15 +901,6 @@ module Yast
     publish :function => :Overview, :type => "list ()"
 
     protected
-
-    # Set SELinux settings
-    # @return true on success
-    def write_selinux
-      return if !@Settings["SELINUX_MODE"] || @Settings["SELINUX_MODE"].empty?
-      selinux = Y2Security::SelinuxConfig.new
-      selinux.mode = @Settings["SELINUX_MODE"]
-      selinux.save
-    end
 
     SELINUX_PACKAGE = "selinux-policy-targeted"
     # Ensure that the needed packge for SELinux will be installed

--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -567,18 +567,17 @@ module Yast
     #
     # @return true on success
     def write_selinux
-      return if @Settings["SELINUX_MODE"].to_s.empty?
+      return if @Settings["SELINUX_MODE"].empty?
 
-      selinux = Y2Security::Selinux.new
-      selinux.mode = @Settings["SELINUX_MODE"]
+      selinux_config.mode = @Settings["SELINUX_MODE"]
 
       # Y2Security::Selinux.mode= fallbacks to the "Disabled" mode when wrong value is given.
       # In consequence, let's check that the mode still being the same before saving it.
-      if selinux.mode.id.to_s != @Settings["SELINUX_MODE"]
+      if selinux_config.mode.id.to_s != @Settings["SELINUX_MODE"]
         log.info("The set SELinux mode does not match with the requested one. Not saving it.")
         false
       else
-        selinux.save
+        selinux_config.save
       end
     end
 

--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -994,6 +994,13 @@ module Yast
     end
   end
 
+  # Returns a SELinux configuration handler
+  #
+  # @return [Y2Security::Selinux] the SELinux config handler
+  def selinux_config
+    @selinux_config ||= Y2Security::Selinux.new
+  end
+
   # Checks if the service is allowed (i.e. not considered 'extra')
   #
   # @return [Boolean] true whether the service is expected (mandatory or optional)

--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -32,7 +32,7 @@ require "cfa/shadow_config"
 require "yaml"
 require "security/ctrl_alt_del_config"
 require "security/display_manager"
-require "y2security/selinux_config"
+require "y2security/selinux"
 
 module Yast
   class SecurityClass < Module
@@ -448,7 +448,7 @@ module Yast
     end
 
     def read_selinux_settings
-      current_mode = Y2Security::SelinuxConfig.new.running_mode.id.to_s
+      current_mode = Y2Security::Selinux.new.running_mode.id.to_s
       if current_mode != "disabled"
         @Settings["SELINUX_MODE"] = current_mode
       else
@@ -568,7 +568,7 @@ module Yast
     # @return true on success
     def write_selinux
       return if !@Settings["SELINUX_MODE"] || @Settings["SELINUX_MODE"].empty?
-      selinux = Y2Security::SelinuxConfig.new
+      selinux = Y2Security::Selinux.new
       selinux.mode = @Settings["SELINUX_MODE"]
       selinux.save
     end

--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -33,7 +33,6 @@ require "yaml"
 require "security/ctrl_alt_del_config"
 require "security/display_manager"
 require "y2security/selinux_config"
-require "autoinstall/autoinst_issues/invalid_value"
 
 module Yast
   class SecurityClass < Module
@@ -804,20 +803,6 @@ module Yast
             tmpSettings[k] = settings[@obsolete_login_defs[k]] || v
           end
         end
-      end
-
-      #Checking value semantic
-      selinux_values = Y2Security::SelinuxConfig.new.modes.map {|m| m.id.to_s}
-      if !selinux_values.include?(settings["SELINUX_MODE"])
-        Yast::AutoInstall.issues_list.add(
-          :invalid_value,
-          "security",
-          "selinux_mode",
-          settings["SELINUX_MODE"],
-          _("Wrong SELinux mode. Possible values: ") +
-          selinux_values.join(", "),
-          :warn
-        )
       end
 
       @Settings = tmpSettings

--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -565,13 +565,24 @@ module Yast
     end
 
     # Set SELinux settings
+    #
     # @return true on success
     def write_selinux
-      return if !@Settings["SELINUX_MODE"] || @Settings["SELINUX_MODE"].empty?
+      return if @Settings["SELINUX_MODE"].to_s.empty?
+
       selinux = Y2Security::Selinux.new
       selinux.mode = @Settings["SELINUX_MODE"]
-      selinux.save
+
+      # Y2Security::Selinux.mode= fallbacks to the "Disabled" mode when wrong value is given.
+      # In consequence, let's check that the mode still being the same before saving it.
+      if selinux.mode.id.to_s != @Settings["SELINUX_MODE"]
+        log.info("The set SELinux mode does not match with the requested one. Not saving it.")
+        false
+      else
+        selinux.save
+      end
     end
+
 
     # Write settings related to PAM behavior
     def write_pam_settings

--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -448,8 +448,7 @@ module Yast
     end
 
     def read_selinux_settings
-      selinux = Y2Security::SelinuxConfig.new
-      current_mode = selinux.running_mode.id.to_s
+      current_mode = Y2Security::SelinuxConfig.new.running_mode.id.to_s
       if current_mode != "disabled"
         @Settings["SELINUX_MODE"] = current_mode
       else

--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -448,12 +448,11 @@ module Yast
         "#{@Settings['HIBERNATE_SYSTEM']}"
     end
 
+    # Sets the SELINUX_MODE setting
+    #
+    # @see Y2Security::Selinux
     def read_selinux_settings
-      @Settings.delete("SELINUX_MODE")
-
-      if selinux_config.mode.id != :disabled
-        @Settings["SELINUX_MODE"] = selinux_config.mode.id.to_s
-      end
+      @Settings["SELINUX_MODE"] = selinux_config.mode.id.to_s
 
       log.debug "SELINUX_MODE (after #{__callee__}): #{@Settings['SELINUX_MODE']}"
     end

--- a/test/levels_test.rb
+++ b/test/levels_test.rb
@@ -50,6 +50,7 @@ module Yast
         change_scr_root(File.join(DATA_PATH, "system"))
         stub_scr_write
         allow(Package).to receive(:Installed).with("systemd").and_return true
+        allow(Security.selinux_config).to receive(:save)
       end
 
       after do

--- a/test/security_test.rb
+++ b/test/security_test.rb
@@ -111,6 +111,7 @@ module Yast
       it "writes and applies all the settings" do
         expect(Security).to receive(:write_to_locations)
         expect(Security).to receive(:write_shadow_config)
+        expect(Security).to receive(:write_selinux)
         expect(Security).to receive(:write_console_shutdown)
         expect(Security).to receive(:write_pam_settings)
         expect(Security).to receive(:write_polkit_settings)
@@ -236,6 +237,18 @@ module Yast
         expect(shadow_config).to receive(:fail_delay=).with("10")
         expect(shadow_config).to receive(:save)
         Security.write_shadow_config
+      end
+    end
+
+    describe "#write_selinux" do
+      before do
+        Security.Settings["SELINUX_MODE"] = "disabled"
+      end
+
+      it "writes bootloader settings" do
+        expect_any_instance_of(Y2Security::SelinuxConfig).to receive(:mode=).with(:disabled)
+        expect_any_instance_of(Y2Security::SelinuxConfig).to receive(save)
+        Security.write_selinix
       end
     end
 

--- a/test/security_test.rb
+++ b/test/security_test.rb
@@ -743,7 +743,7 @@ module Yast
             and_return(:permissive)
         end
         it "reads \"permissive\" value" do
-          Security.read_shadow_config
+          Security.read_selinux_settings
           expect(Security.Settings["SELINUX_MODE"]).to eq("permissive")
         end
       end
@@ -754,7 +754,7 @@ module Yast
             and_return(:disabled)
         end
         it "removes SELINUX_MODE from hash" do
-          Security.read_shadow_config
+          Security.read_selinux_settings
           expect(Security.Settings.has_key?("SELINUX_MODE")).to eq(false)
         end
       end

--- a/test/security_test.rb
+++ b/test/security_test.rb
@@ -246,7 +246,7 @@ module Yast
       end
 
       it "writes bootloader settings" do
-        expect_any_instance_of(Y2Security::SelinuxConfig).to receive(:mode=).with(disabled)
+        expect_any_instance_of(Y2Security::SelinuxConfig).to receive(:mode=).with("disabled")
         expect_any_instance_of(Y2Security::SelinuxConfig).to receive(:save)
         Security.write_selinux
       end

--- a/test/security_test.rb
+++ b/test/security_test.rb
@@ -111,7 +111,7 @@ module Yast
       it "writes and applies all the settings" do
         expect(Security).to receive(:write_to_locations)
         expect(Security).to receive(:write_shadow_config)
-#        expect(Security).to receive(:write_selinux)
+        expect(Security).to receive(:write_selinux)
         expect(Security).to receive(:write_console_shutdown)
         expect(Security).to receive(:write_pam_settings)
         expect(Security).to receive(:write_polkit_settings)
@@ -248,7 +248,7 @@ module Yast
       it "writes bootloader settings" do
         expect_any_instance_of(Y2Security::SelinuxConfig).to receive(:mode=).with(:disabled)
         expect_any_instance_of(Y2Security::SelinuxConfig).to receive(:save)
-        Security.write_selinix
+        Security.write_selinux
       end
     end
 

--- a/test/security_test.rb
+++ b/test/security_test.rb
@@ -742,7 +742,7 @@ module Yast
       context "SELinux is available" do
         before do
           mode.mode = "permissive"
-          allow_any_instance_of(Y2Security::Selinux).to receive(:running_mode).
+          allow_any_instance_of(Y2Security::Selinux).to receive(:mode).
             and_return(mode.mode)
         end
         it "reads \"permissive\" value" do

--- a/test/security_test.rb
+++ b/test/security_test.rb
@@ -737,29 +737,27 @@ module Yast
     end
 
     describe "#read_selinux_settings" do
-      let(:mode) { Y2Security::Selinux.new }
+      before do
+        allow(subject.selinux_config).to receive(:mode).and_return(mode)
+      end
 
-      context "SELinux is available" do
-        before do
-          mode.mode = "permissive"
-          allow_any_instance_of(Y2Security::Selinux).to receive(:mode).
-            and_return(mode.mode)
-        end
-        it "reads \"permissive\" value" do
+      context "when SELinux is enable" do
+        let(:mode) { Y2Security::Selinux::Mode.find(:permissive) }
+
+        it "reads its mode id as string" do
           Security.read_selinux_settings
-          expect(Security.Settings["SELINUX_MODE"]).to eq("permissive")
+
+          expect(Security.Settings["SELINUX_MODE"]).to eq(mode.id.to_s)
         end
       end
 
-      context "SELinux is NOT available" do
-        before do
-          mode.mode = "disabled"
-          allow_any_instance_of(Y2Security::Selinux).to receive(:running_mode).
-            and_return(mode.mode)
-        end
-        it "removes SELINUX_MODE from hash" do
+      context "when SELinux is NOT enable" do
+        let(:mode) { Y2Security::Selinux::Mode.find(:disabled) }
+
+        it "ensures SELINUX_MODE is removed from hash settings" do
           Security.read_selinux_settings
-          expect(Security.Settings.has_key?("SELINUX_MODE")).to eq(false)
+
+          expect(Security.Settings).to_not have_key("SELINUX_MODE")
         end
       end
     end

--- a/test/security_test.rb
+++ b/test/security_test.rb
@@ -247,7 +247,7 @@ module Yast
 
       it "writes bootloader settings" do
         expect_any_instance_of(Y2Security::SelinuxConfig).to receive(:mode=).with(:disabled)
-        expect_any_instance_of(Y2Security::SelinuxConfig).to receive(save)
+        expect_any_instance_of(Y2Security::SelinuxConfig).to receive(:save)
         Security.write_selinix
       end
     end

--- a/test/security_test.rb
+++ b/test/security_test.rb
@@ -246,8 +246,8 @@ module Yast
       end
 
       it "writes bootloader settings" do
-        expect_any_instance_of(Y2Security::SelinuxConfig).to receive(:mode=).with("disabled")
-        expect_any_instance_of(Y2Security::SelinuxConfig).to receive(:save)
+        expect_any_instance_of(Y2Security::Selinux).to receive(:mode=).with("disabled")
+        expect_any_instance_of(Y2Security::Selinux).to receive(:save)
         Security.write_selinux
       end
     end
@@ -737,12 +737,12 @@ module Yast
     end
 
     describe "#read_selinux_settings" do
-      let(:mode) { Y2Security::SelinuxConfig.new }
-      
+      let(:mode) { Y2Security::Selinux.new }
+
       context "SELinux is available" do
         before do
           mode.mode = "permissive"
-          allow_any_instance_of(Y2Security::SelinuxConfig).to receive(:running_mode).
+          allow_any_instance_of(Y2Security::Selinux).to receive(:running_mode).
             and_return(mode.mode)
         end
         it "reads \"permissive\" value" do
@@ -753,8 +753,8 @@ module Yast
 
       context "SELinux is NOT available" do
         before do
-          mode.mode = "disabled"          
-          allow_any_instance_of(Y2Security::SelinuxConfig).to receive(:running_mode).
+          mode.mode = "disabled"
+          allow_any_instance_of(Y2Security::Selinux).to receive(:running_mode).
             and_return(mode.mode)
         end
         it "removes SELINUX_MODE from hash" do

--- a/test/security_test.rb
+++ b/test/security_test.rb
@@ -736,6 +736,30 @@ module Yast
       end
     end
 
+    describe "#read_selinux_settings" do
+      context "SELinux is available" do
+        before do
+          allow_any_instance_of(Y2Security::SelinuxConfig).to receive(:running_mode).
+            and_return(:permissive)
+        end
+        it "reads \"permissive\" value" do
+          Security.read_shadow_config
+          expect(Security.Settings["SELINUX_MODE"]).to eq("permissive")
+        end
+      end
+
+      context "SELinux is NOT available" do
+        before do
+          allow_any_instance_of(Y2Security::SelinuxConfig).to receive(:running_mode).
+            and_return(:disabled)
+        end
+        it "removes SELINUX_MODE from hash" do
+          Security.read_shadow_config
+          expect(Security.Settings.has_key?("SELINUX_MODE")).to eq(false)
+        end
+      end
+    end
+
     describe "#Read" do
       it "reads settings and returns true" do
         expect(Security).to receive(:read_from_locations)

--- a/test/security_test.rb
+++ b/test/security_test.rb
@@ -241,36 +241,23 @@ module Yast
     end
 
     describe "#write_selinux" do
-      before do
-        allow(subject.selinux_config).to receive(:mode).and_return(selinux_mode)
+      let(:requested_mode) { "enforcing" }
 
+      before do
+        allow(subject.selinux_config).to receive(:save)
         subject.Settings["SELINUX_MODE"] = requested_mode
       end
 
-      context "when SELinux mode is the same than requested" do
-        let(:requested_mode) { "permissive" }
-        let(:selinux_mode) { Y2Security::Selinux::Mode.find(:permissive) }
+      it "sets the SELinux mode" do
+        expect(subject.selinux_config).to receive(:mode=).with(requested_mode)
 
-        it "saves the selinux config" do
-          expect(subject.selinux_config).to receive(:save)
-
-          subject.write_selinux
-        end
+        subject.write_selinux
       end
 
-      context "when SELinux mode is NOT the same than requested" do
-        let(:requested_mode) { "whatever" }
-        let(:selinux_mode) { Y2Security::Selinux::Mode.find(:disabled) }
+      it "saves the selinux config" do
+        expect(subject.selinux_config).to receive(:save)
 
-        it "returns false" do
-          expect(subject.write_selinux).to eq(false)
-        end
-
-        it "does not save the selinux config" do
-          expect(subject.selinux_config).to_not receive(:save)
-
-          subject.write_selinux
-        end
+        subject.write_selinux
       end
     end
 

--- a/test/security_test.rb
+++ b/test/security_test.rb
@@ -739,8 +739,10 @@ module Yast
     describe "#read_selinux_settings" do
       context "SELinux is available" do
         before do
+          mode = Y2Security::SelinuxConfig.new
+          mode.mode = "permissive"
           allow_any_instance_of(Y2Security::SelinuxConfig).to receive(:running_mode).
-            and_return(:permissive)
+            and_return(mode.mode)
         end
         it "reads \"permissive\" value" do
           Security.read_selinux_settings
@@ -750,8 +752,10 @@ module Yast
 
       context "SELinux is NOT available" do
         before do
+          mode = Y2Security::SelinuxConfig.new
+          mode.mode = "disabled"          
           allow_any_instance_of(Y2Security::SelinuxConfig).to receive(:running_mode).
-            and_return(:disabled)
+            and_return(mode.mode)
         end
         it "removes SELINUX_MODE from hash" do
           Security.read_selinux_settings

--- a/test/security_test.rb
+++ b/test/security_test.rb
@@ -246,7 +246,7 @@ module Yast
       end
 
       it "writes bootloader settings" do
-        expect_any_instance_of(Y2Security::SelinuxConfig).to receive(:mode=).with(:disabled)
+        expect_any_instance_of(Y2Security::SelinuxConfig).to receive(:mode=).with(disabled)
         expect_any_instance_of(Y2Security::SelinuxConfig).to receive(:save)
         Security.write_selinux
       end

--- a/test/security_test.rb
+++ b/test/security_test.rb
@@ -111,7 +111,7 @@ module Yast
       it "writes and applies all the settings" do
         expect(Security).to receive(:write_to_locations)
         expect(Security).to receive(:write_shadow_config)
-        expect(Security).to receive(:write_selinux)
+#        expect(Security).to receive(:write_selinux)
         expect(Security).to receive(:write_console_shutdown)
         expect(Security).to receive(:write_pam_settings)
         expect(Security).to receive(:write_polkit_settings)

--- a/test/security_test.rb
+++ b/test/security_test.rb
@@ -759,28 +759,24 @@ module Yast
     end
 
     describe "#read_selinux_settings" do
+      let(:mode) { double("Y2Security::Selinux::Mode", id: :enforcing) }
+
       before do
         allow(subject.selinux_config).to receive(:mode).and_return(mode)
       end
 
-      context "when SELinux is enable" do
-        let(:mode) { Y2Security::Selinux::Mode.find(:permissive) }
+      it "reads the selinux mode" do
+        expect(subject.selinux_config).to receive(:mode)
 
-        it "reads its mode id as string" do
-          Security.read_selinux_settings
-
-          expect(Security.Settings["SELINUX_MODE"]).to eq(mode.id.to_s)
-        end
+        subject.read_selinux_settings
       end
 
-      context "when SELinux is NOT enable" do
-        let(:mode) { Y2Security::Selinux::Mode.find(:disabled) }
+      it "sets the SELINUX_MODE setting" do
+        expect(Security.Settings["SELINUX_MODE"]).to eq("")
 
-        it "ensures SELINUX_MODE is removed from hash settings" do
-          Security.read_selinux_settings
+        Security.read_selinux_settings
 
-          expect(Security.Settings).to_not have_key("SELINUX_MODE")
-        end
+        expect(Security.Settings["SELINUX_MODE"]).to eq(mode.id.to_s)
       end
     end
 
@@ -792,6 +788,7 @@ module Yast
         expect(Security).to receive(:read_pam_settings)
         expect(Security).to receive(:read_permissions)
         expect(Security).to receive(:read_polkit_settings)
+        expect(Security).to receive(:read_selinux_settings)
 
         expect(Security.Read).to eql(true)
       end

--- a/test/security_test.rb
+++ b/test/security_test.rb
@@ -737,9 +737,10 @@ module Yast
     end
 
     describe "#read_selinux_settings" do
+      let(:mode) { Y2Security::SelinuxConfig.new }
+      
       context "SELinux is available" do
         before do
-          mode = Y2Security::SelinuxConfig.new
           mode.mode = "permissive"
           allow_any_instance_of(Y2Security::SelinuxConfig).to receive(:running_mode).
             and_return(mode.mode)
@@ -752,7 +753,6 @@ module Yast
 
       context "SELinux is NOT available" do
         before do
-          mode = Y2Security::SelinuxConfig.new
           mode.mode = "disabled"          
           allow_any_instance_of(Y2Security::SelinuxConfig).to receive(:running_mode).
             and_return(mode.mode)


### PR DESCRIPTION
Related to https://github.com/yast/yast-security/pull/83, this PR adds support for SELinux in AutoYaST.


---

<sub>Replaces #85 after _updating_ it to make use of recent changes introduced in yast/yast-security#87</sub>