### PR TITLE
Fix popup

### DIFF
--- a/package/yast2-security.changes
+++ b/package/yast2-security.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Feb 15 11:35:59 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
+
+- Adapted unit test to recent changes in Yast::Report (related to
+  bsc#1179893).
+- 4.3.8
+
+-------------------------------------------------------------------
 Tue Dec 15 12:33:52 UTC 2020 - schubi <schubi@localhost>
 
 - Removed old code for sysvinit configuration (bsc#1175494).

--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-security
-Version:        4.3.7
+Version:        4.3.8
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/test/security_test.rb
+++ b/test/security_test.rb
@@ -241,6 +241,8 @@ module Yast
 
     describe "#write_kernel_settings" do
       before do
+        # there are some failure with running uname in chroot without root perms
+        allow(Yast::Report).to receive(:Error)
         change_scr_root(File.join(DATA_PATH, "system"))
         Security.read_kernel_settings
         stub_scr_write
@@ -520,6 +522,8 @@ module Yast
 
     describe "#read_kernel_settings" do
       before do
+        # there are some failure with running uname in chroot without root perms
+        allow(Yast::Report).to receive(:Error)
         change_scr_root(File.join(DATA_PATH, "system"))
         Security.Settings["kernel.sysrq"]                 = nil
         Security.Settings["net.ipv4.tcp_syncookies"]      = nil


### PR DESCRIPTION
This pull request in yast-yast2 (https://github.com/yast/yast-yast2/pull/1122) changed the behavior during unit tests of `Yast::Report` and `Yast2::Popup`, making necessary to add some extra mocking to prevent YaST from trying to open windows during the test execution.

As far as we know, that affected the test-suites of: yast-storage-ng, yast-country, yast-firewall, yast-nfs-server, yast-nis-client, yast-pam, yast-security, yast-services-manager and yast-sysconfig.

This should fix the problem for this repository.