### PR TITLE
[master] Add SELinux support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM registry.opensuse.org/yast/sle-15/sp2/containers/yast-ruby
+FROM registry.opensuse.org/yast/head/containers/yast-ruby:latest
 COPY . /usr/src/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,0 @@
-FROM registry.opensuse.org/yast/head/containers/yast-ruby:latest
-COPY . /usr/src/app

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,5 @@
 require "yast/rake"
 
-Yast::Tasks.submit_to :sle15sp2
-
 Yast::Tasks.configuration do |conf|
   # lets ignore license check for now
   conf.skip_license_check << /.*/

--- a/package/yast2-security.changes
+++ b/package/yast2-security.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Feb 16 13:36:34 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- jsc#SMO-20, jsc#SLE-17342:
+  - Add class for managing SELinux configuration.
+  - AutoYaST: add support for SELinux configuration.
+- 4.3.9
+
+-------------------------------------------------------------------
 
 Mon Feb 15 11:35:59 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
 

--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-security
-Version:        4.3.8
+Version:        4.3.9
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/clients/security_auto.rb
+++ b/src/clients/security_auto.rb
@@ -84,9 +84,9 @@ module Yast
       # Import Data
       elsif @func == "Import"
 
-        #Checking value semantic
-        if @param.has_key?("selinux_mode")
-          selinux_values = Y2Security::Selinux.new.modes.map {|m| m.id.to_s}
+        # Checking value semantic
+        if @param.key?("selinux_mode")
+          selinux_values = Y2Security::Selinux.new.modes.map { |m| m.id.to_s }
           if !selinux_values.include?(@param["selinux_mode"])
             Yast::AutoInstall.issues_list.add(
               :invalid_value,
@@ -151,7 +151,7 @@ module Yast
       Builtins.y2milestone("Security auto finished")
       Builtins.y2milestone("----------------------------------------")
 
-      deep_copy(@ret) 
+      deep_copy(@ret)
 
       # EOF
     end

--- a/src/lib/cfa/selinux.rb
+++ b/src/lib/cfa/selinux.rb
@@ -78,8 +78,6 @@ module CFA
       false
     end
 
-    private
-
     # Default path to the SELinux config file
     PATH = "/etc/selinux/config".freeze
     private_constant :PATH

--- a/src/lib/y2security/selinux.rb
+++ b/src/lib/y2security/selinux.rb
@@ -142,7 +142,7 @@ module Y2Security
 
       # enforcing=0 means that "permissive" mode will be used, despite the SELINUX value used in the
       # configuration file.
-      enforcing_mode > 0 ? Mode.find(:enforcing) : Mode.find(:permissive)
+      (enforcing_mode > 0) ? Mode.find(:enforcing) : Mode.find(:permissive)
     end
 
     # Returns a collection holding all known SELinux modes
@@ -217,7 +217,7 @@ module Y2Security
       product_feature_settings[:configurable] || false
     end
 
-    private
+  private
 
     # Path to the SELinux getenforce command
     GETENFORCE_PATH = "/usr/sbin/getenforce".freeze
@@ -358,8 +358,6 @@ module Y2Security
       end
       alias_method :to_human_string, :name
 
-      private
-
       # All known SELinux modes
       #
       # This is _the main_ or _base_ configuration for known SELinux modes. However, note that, for
@@ -378,12 +376,12 @@ module Y2Security
       ALL = [
         new(:disabled,   N_("Disabled"),   false, false),
         new(:permissive, N_("Permissive"), true,  false),
-        new(:enforcing,  N_("Enforcing"),  true,  true),
+        new(:enforcing,  N_("Enforcing"),  true,  true)
       ].freeze
       private_constant :ALL
 
       # Known keys for setting a SELinux mode via kernel command line
-      KERNEL_OPTIONS = ["security", "selinux", "enforcing"]
+      KERNEL_OPTIONS = ["security", "selinux", "enforcing"].freeze
       private_constant :KERNEL_OPTIONS
     end
   end

--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -449,7 +449,6 @@ module Yast
         "#{@Settings['HIBERNATE_SYSTEM']}"
     end
 
-
     # The name of the PAM module to deal with password quality. Either
     # "pwquality" or "cracklib". See bug #1171318 why this is needed.
     def pwquality_module
@@ -552,7 +551,6 @@ module Yast
       selinux_config.mode = @Settings["SELINUX_MODE"]
       selinux_config.save
     end
-
 
     # Write settings related to PAM behavior
     def write_pam_settings
@@ -786,6 +784,7 @@ module Yast
       end
 
       return true if settings == {}
+
       @modified = true
       tmpSettings = {}
       @Settings.each do |k, v|

--- a/test/cfa/selinux_test.rb
+++ b/test/cfa/selinux_test.rb
@@ -29,8 +29,7 @@ describe CFA::Selinux do
 
   let(:selinux_path) { "config" }
   let(:file_handler) { File }
-  let(:file_path) { File.join(DATA_PATH, "system/etc/selinux/config")  }
-
+  let(:file_path) { File.join(DATA_PATH, "system/etc/selinux/config") }
 
   describe ".load" do
     context "when file exist" do

--- a/test/security_test.rb
+++ b/test/security_test.rb
@@ -335,7 +335,7 @@ module Yast
             it "sets settings for shutdown as 'reboot'" do
               allow(FileUtils).to receive(:Exists).with(ctrl_alt_del_file) { false }
 
-              Security.ReadConsoleShutdown              
+              Security.ReadConsoleShutdown
               expect(Security.Settings["CONSOLE_SHUTDOWN"]).to eql("reboot")
             end
           end
@@ -357,7 +357,7 @@ module Yast
               allow(SCR).to receive(:Read).with(path(".target.symlink"), ctrl_alt_del_file)
                 .and_return(target_link)
 
-              Security.ReadConsoleShutdown              
+              Security.ReadConsoleShutdown
               expect(Security.Settings["CONSOLE_SHUTDOWN"]).to eql("halt")
             end
 
@@ -709,7 +709,7 @@ module Yast
         expect(Yast::PackagesProposal).to receive(:SetResolvables)
           .with(anything, :pattern, selinux_patterns)
 
-        expect(Security.Import({"SELINUX_MODE" => "permissive"}))
+        expect(Security.Import("SELINUX_MODE" => "permissive"))
       end
 
       context "when Settings keys exists in given settings" do

--- a/test/y2security/selinux_test.rb
+++ b/test/y2security/selinux_test.rb
@@ -202,7 +202,7 @@ describe Y2Security::Selinux do
     let(:cheetah_error) { Cheetah::ExecutionFailed.new([], "", nil, nil) }
 
     context "when getenforce tool is available" do
-      let(:getenforce_output) { "Enforcing\n"  }
+      let(:getenforce_output) { "Enforcing\n" }
 
       before do
         allow(Yast::Execute).to receive(:locally!).with(*getenforce_cmd)
@@ -461,14 +461,12 @@ describe Y2Security::Selinux do
       let(:selinux_patterns) { "one-pattern another-pattern" }
 
       it "returns an array holding defined patterns" do
-        expect(subject.needed_patterns).to eq([
-          "one-pattern",
-          "another-pattern"
-        ])
+        expect(subject.needed_patterns).to eq(["one-pattern", "another-pattern"])
       end
 
       context "but selected Disabled SELinux mode" do
         let(:mode) { disabled_mode }
+
         it "returns an empty array" do
           expect(subject.needed_patterns).to eq([])
         end


### PR DESCRIPTION
In summary, it adds the SELinux support (also in AutoYaST).

Part of https://trello.com/c/g94xQBDM/ (internal link) and related to work mainly done in https://github.com/yast/yast-security/pull/83, https://github.com/yast/yast-security/pull/87, and https://github.com/yast/yast-security/pull/88.

---

Changes picked from SLE-15-SP2 branch following the [YaST Maintenance work flow](https://yastgithubio.readthedocs.io/en/latest/maintenance-branches/#maintenance-work-flow).



