### PR TITLE
[SLE-15-SP2] Move SELinux .autorelabel file

### DIFF
--- a/package/yast2-security.changes
+++ b/package/yast2-security.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Feb 22 13:45:58 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Move SELinux .autorelabel file from / to /etc/selinux if root
+  filesystem will be mounted as read only (jsc#SLE-17307).
+- 4.2.19
+
+-------------------------------------------------------------------
 Sun Feb 14 21:13:17 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
 - AutoYaST: add support for SELinux configuration (jsc#SMO-20,

--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-security
-Version:        4.2.18
+Version:        4.2.19
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -40,6 +40,8 @@ BuildRequires:  rubygem(%{rb_default_ruby_abi}:rspec)
 BuildRequires:  yast2 >= 4.2.66
 # CFA::Selinux
 BuildRequires:  augeas-lenses
+# Y2Storage::StorageManager
+BuildRequires:  yast2-storage-ng
 # Unfortunately we cannot move this to macros.yast,
 # bcond within macros are ignored by osc/OBS.
 %bcond_with yast_run_ci_tests
@@ -56,6 +58,8 @@ Requires:       yast2-ruby-bindings >= 1.0.0
 Requires:       yast2-bootloader
 # CFA::Selinux
 Requires:       augeas-lenses
+# Y2Storage::StorageManager
+Requires:       yast2-storage-ng
 
 Provides:       y2c_sec yast2-config-security
 Provides:       yast2-trans-security y2t_sec

--- a/src/lib/y2security/selinux.rb
+++ b/src/lib/y2security/selinux.rb
@@ -187,12 +187,16 @@ module Y2Security
     def save
       return false unless configurable?
 
+      log.info("Modifying Bootlooader kernel params using #{mode.options}")
       Yast::Bootloader.modify_kernel_params(mode.options)
+
+      log.info("Saving SELinux config file to set #{mode.id} mode")
       config_file.selinux = mode.id.to_s
       config_file.save
 
       return true if Yast::Mode.installation
 
+      log.info("Saving Bootloader configuration")
       Yast::Bootloader.Write
     end
 

--- a/src/lib/y2security/selinux.rb
+++ b/src/lib/y2security/selinux.rb
@@ -19,6 +19,7 @@
 
 require "yast"
 require "yast2/execute"
+require "y2storage/storage_manager"
 require "cfa/selinux"
 
 module Y2Security
@@ -181,8 +182,8 @@ module Y2Security
     # @see Yast::Bootloader#modify_kernel_params
     # @see CFA::Selinux#save
     #
-    # @return [Boolean] true if running in installation where selinux is configurable;
-    #                   false if running in installation where selinux is not configurable;
+    # @return [Boolean] true if running in installation where SELinux is configurable;
+    #                   false if running in installation where SELinux is not configurable;
     #                   the Yast::Bootloader#Write return value otherwise
     def save
       return false unless configurable?
@@ -193,6 +194,12 @@ module Y2Security
       log.info("Saving SELinux config file to set #{mode.id} mode")
       config_file.selinux = mode.id.to_s
       config_file.save
+
+      if relocate_autorelabel_file?
+        log.info("Detected a read-only root fs: relocating .autorelabel file")
+
+        relocate_autorelabel_file
+      end
 
       return true if Yast::Mode.installation
 
@@ -226,6 +233,22 @@ module Y2Security
     # Path to the SELinux getenforce command
     GETENFORCE_PATH = "/usr/sbin/getenforce".freeze
     private_constant :GETENFORCE_PATH
+
+    # Path to .autorelabel file in root
+    ROOT_AUTORELABEL_PATH = "/.autorelabel".freeze
+    private_constant :ROOT_AUTORELABEL_PATH
+
+    # Path to .autorelabel file in /etc
+    ETC_AUTORELABEL_PATH = "/etc/selinux/.autorelabel".freeze
+    private_constant :ETC_AUTORELABEL_PATH
+
+    # Path to `rm` command
+    RM_COMMAND = "/usr/bin/rm".freeze
+    private_constant :RM_COMMAND
+
+    # Path to `touch` command
+    TOUCH_COMMAND = "/usr/bin/touch".freeze
+    private_constant :TOUCH_COMMAND
 
     # Returns the values for the SELinux setting from the product features
     #
@@ -298,6 +321,41 @@ module Y2Security
     # @see Yast::Bootloader#kernel_param
     def read_param(key)
       Yast::Bootloader.kernel_param(:common, key.to_s)
+    end
+
+    # Whether the .autorelabel file should be relocated
+    #
+    # @see https://jira.suse.com/browse/SLE-17307
+    #
+    # @return [Booelan] true if root fs will mounted as read only, SELinux is not disabled,
+    #                   and running in the installation mode; false otherwise
+    def relocate_autorelabel_file?
+      mode.to_sym != :disabled && Yast::Mode.installation && read_only_root_fs?
+    end
+
+    # Relocates the .autorelabel file from #{ROOT_AUTORELABEL_PATH} to #{ETC_AUTORELABEL_PATH} by
+    # removing the first and touching the latter.
+    #
+    # @see #save
+    # @see https://jira.suse.com/browse/SLE-17307
+    def relocate_autorelabel_file
+      log.info("Deleting #{ROOT_AUTORELABEL_PATH} file")
+      Yast::Execute.stdout.on_target!(RM_COMMAND, ROOT_AUTORELABEL_PATH)
+
+      log.info("Touching #{ETC_AUTORELABEL_PATH} file")
+      Yast::Execute.stdout.on_target!(TOUCH_COMMAND, ETC_AUTORELABEL_PATH)
+    end
+
+    # Whether the root file system will be mounted as read only
+    #
+    # @return [Booelan] true if "ro" is one of the root fs mount options; false otherwise
+    def read_only_root_fs?
+      staging_graph = Y2Storage::StorageManager.instance.staging
+      root_fs = staging_graph.filesystems.find(&:root?)
+
+      return false unless root_fs
+
+      root_fs.mount_options.include?("ro")
     end
 
     # Model that represents a SELinux mode

--- a/test/y2security/selinux_test.rb
+++ b/test/y2security/selinux_test.rb
@@ -420,6 +420,12 @@ describe Y2Security::Selinux do
           subject.save
         end
 
+        it "does not write the bootloader configuration" do
+          expect(Yast::Bootloader).to_not receive(:Write)
+
+          subject.save
+        end
+
         it "returns false" do
           expect(subject.save).to eq(false)
         end
@@ -430,6 +436,19 @@ describe Y2Security::Selinux do
       it "modifies the bootloader kernel params" do
         expect(Yast::Bootloader).to receive(:modify_kernel_params)
           .with(enforcing_mode.options)
+
+        subject.save
+      end
+
+      it "writes the bootloader configuration" do
+        expect(Yast::Bootloader).to receive(:Write)
+
+        subject.save
+      end
+
+      it "changes the mode in the configuration file" do
+        expect(config_file).to receive(:selinux=).with("enforcing")
+        expect(config_file).to receive(:save)
 
         subject.save
       end


### PR DESCRIPTION
As part of https://jira.suse.com/browse/SLE-17307 Epic (internal  link), the `.autorelabel` file should be moved from `/` to `/etc/selinux/` when the root filesystem will be mounted as read-only.

<details>
<summary>Show/hide an excerpt of requirement description</summary>

  > [...]
  > 
  > 6. If a read-only root filesystem is used:
  >      /.autorelabel needs to be deleted
  >      /etc/selinux/.autorelabel needs to be touched
  > 
</details>

---

* Added unit tests
* Tested manually in a SLE-15-SP2
  
  <details>
  <summary>Show/hide screenshot</summary>

  ---

  ![selinux_autorelabel](https://user-images.githubusercontent.com/1691872/108821615-c8017080-75b5-11eb-8d4f-bb5cf1a219d9.png)
   </details>

---

Related to #87 