### PR TITLE
[master] Move SELinux .autorelabel file

### DIFF
--- a/package/yast2-security.changes
+++ b/package/yast2-security.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Feb 23 15:04:15 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Move SELinux .autorelabel file from / to /etc/selinux if root
+  filesystem will be mounted as read only (jsc#SLE-17307).
+- 4.3.10
+
+-------------------------------------------------------------------
 Tue Feb 16 13:36:34 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
 - jsc#SMO-20, jsc#SLE-17342:

--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -41,6 +41,8 @@ BuildRequires:  rubygem(%{rb_default_ruby_abi}:rspec)
 BuildRequires:  yast2 >= 4.2.66
 # CFA::Selinux
 BuildRequires:  augeas-lenses
+# Y2Storage::StorageManager
+BuildRequires:  yast2-storage-ng
 # Unfortunately we cannot move this to macros.yast,
 # bcond within macros are ignored by osc/OBS.
 %bcond_with yast_run_ci_tests
@@ -59,6 +61,8 @@ Requires:       yast2-pam >= 4.3.1
 Requires:       yast2-bootloader
 # CFA::Selinux
 Requires:       augeas-lenses
+# Y2Storage::StorageManager
+Requires:       yast2-storage-ng
 
 Provides:       y2c_sec yast2-config-security
 Provides:       yast2-trans-security y2t_sec

--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-security
-Version:        4.3.9
+Version:        4.3.10
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/test/y2security/selinux_test.rb
+++ b/test/y2security/selinux_test.rb
@@ -52,6 +52,8 @@ describe Y2Security::Selinux do
 
   let(:configured_mode) { enforcing_mode }
 
+  let(:read_only_root_fs) { false }
+
   before do
     Yast::ProductFeatures.Import(product_features)
 
@@ -63,6 +65,7 @@ describe Y2Security::Selinux do
       .and_return(selinux_param)
     allow(Yast::Bootloader).to receive(:kernel_param).with(:common, "enforcing")
       .and_return(enforcing_param)
+    allow(subject).to receive(:read_only_root_fs?).and_return(read_only_root_fs)
   end
 
   describe "#mode" do
@@ -365,12 +368,16 @@ describe Y2Security::Selinux do
   describe "#save" do
     let(:write_result) { true }
     let(:selinux_configurable) { true }
+    let(:mode) { enforcing_mode }
     let(:config_file) { double("CFA::Selinux", load: true, save: true, :selinux= => true) }
+    let(:executor) { double("Yast::Execute", on_target!: "") }
 
     before do
       allow(Yast::Bootloader).to receive(:modify_kernel_params)
       allow(Yast::Bootloader).to receive(:Write).and_return(write_result)
+      allow(Yast::Execute).to receive(:stdout).and_return(executor)
       allow(subject).to receive(:config_file).and_return(config_file)
+      allow(subject).to receive(:mode).and_return(mode)
 
       subject.mode = enforcing_mode
     end
@@ -399,6 +406,37 @@ describe Y2Security::Selinux do
           subject.save
         end
 
+        context "and root filesystem will be mounted read-only" do
+          let(:read_only_root_fs) { true }
+
+          it "touches .autorelable file" do
+            expect(executor).to receive(:on_target!).with(/rm/, /autorelabel/)
+            expect(executor).to receive(:on_target!).with(/touch/, /autorelabel/)
+
+            subject.save
+          end
+
+          context "but SELinux is disabled" do
+            let(:mode) { disabled_mode }
+
+            it "does not touch .autorelable file" do
+              expect(executor).to_not receive(:on_target!).with(/rm/, /autorelabel/)
+              expect(executor).to_not receive(:on_target!).with(/touch/, /autorelabel/)
+
+              subject.save
+            end
+          end
+        end
+
+        context "and root filesystem will not be mounted as read-only" do
+          it "does not touch the .autorelable file" do
+            expect(executor).to_not receive(:on_target!).with(/rm/, /autorelabel/)
+            expect(executor).to_not receive(:on_target!).with(/touch/, /autorelabel/)
+
+            subject.save
+          end
+        end
+
         it "returns true" do
           expect(subject.save).to eq(true)
         end
@@ -420,6 +458,19 @@ describe Y2Security::Selinux do
           subject.save
         end
 
+        it "does not touch the .autorelable file" do
+          expect(executor).to_not receive(:on_target!).with(/rm/, /autorelabel/)
+          expect(executor).to_not receive(:on_target!).with(/touch/, /autorelabel/)
+
+          subject.save
+        end
+
+        it "does not write the bootloader configuration" do
+          expect(Yast::Bootloader).to_not receive(:Write)
+
+          subject.save
+        end
+
         it "returns false" do
           expect(subject.save).to eq(false)
         end
@@ -430,6 +481,26 @@ describe Y2Security::Selinux do
       it "modifies the bootloader kernel params" do
         expect(Yast::Bootloader).to receive(:modify_kernel_params)
           .with(enforcing_mode.options)
+
+        subject.save
+      end
+
+      it "writes the bootloader configuration" do
+        expect(Yast::Bootloader).to receive(:Write)
+
+        subject.save
+      end
+
+      it "changes the mode in the configuration file" do
+        expect(config_file).to receive(:selinux=).with("enforcing")
+        expect(config_file).to receive(:save)
+
+        subject.save
+      end
+
+      it "does not touch the .autorelable file" do
+        expect(executor).to_not receive(:on_target!).with(/rm/, /autorelabel/)
+        expect(executor).to_not receive(:on_target!).with(/touch/, /autorelabel/)
 
         subject.save
       end


### PR DESCRIPTION
This PR sync `master` branch with `SLE-15-SP2` after introducing changes to move the _.autorelabel_ SELinux file from `/` to `/etc/selinux/` when the root fs will be mounted as read-only.

See https://github.com/yast/yast-security/pull/94

---

Related to #87 
  