### PR TITLE
Change the unique id for SELinux resolvable

### DIFF
--- a/package/yast2-security.changes
+++ b/package/yast2-security.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Mar  1 11:33:59 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Change the SELinux resolvable unique id used in auto-installation
+  to be consistent with the one used by normal installation
+  (related to jsc#SLE-17342).
+- 4.2.20
+
+-------------------------------------------------------------------
 Mon Feb 22 13:45:58 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
 - Move SELinux .autorelabel file from / to /etc/selinux if root

--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-security
-Version:        4.2.19
+Version:        4.2.20
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -903,7 +903,7 @@ module Yast
     def set_selinux_patterns
       selinux_config.mode = @Settings["SELINUX_MODE"] unless @Settings["SELINUX_MODE"].to_s.empty?
 
-      PackagesProposal.SetResolvables("selinux_patterns", :pattern, selinux_config.needed_patterns)
+      PackagesProposal.SetResolvables("SELinux", :pattern, selinux_config.needed_patterns)
     end
 
     # Sets @missing_mandatory_services honoring the systemd aliases

--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -903,6 +903,8 @@ module Yast
     def set_selinux_patterns
       selinux_config.mode = @Settings["SELINUX_MODE"] unless @Settings["SELINUX_MODE"].to_s.empty?
 
+      # Please, keep the unique id synced with the one used in normal installation
+      # See https://github.com/yast/yast-firewall/blob/c3ae49a1009dbf324fa3558dff6c5e147c495268/src/lib/y2firewall/clients/proposal.rb#L229-L230
       PackagesProposal.SetResolvables("SELinux", :pattern, selinux_config.needed_patterns)
     end
 


### PR DESCRIPTION
Change the `SELinux` resolvable unique id used in auto-installation to be consistent with the one used by normal installation.

See https://github.com/yast/yast-firewall/blob/4c1d0ef2db1f982959124186dbd374d722369773/src/lib/y2firewall/clients/proposal.rb#L229-L230

---

Related to https://github.com/yast/yast-security/pull/88 and https://github.com/yast/yast-firewall/pull/144