### PR TITLE
 Change the unique id for SELinux resolvable

### DIFF
--- a/package/yast2-security.changes
+++ b/package/yast2-security.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Mar  1 11:33:59 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Change the SELinux resolvable unique id used in auto-installation
+  to be consistent with the one used by normal installation
+  (related to jsc#SLE-17342).
+- 4.3.12
+
+-------------------------------------------------------------------
 Mon Mar  1 10:21:28 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
 
 - Move security_finish client to yast2-installation (bsc#1182821)

--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-security
-Version:        4.3.11
+Version:        4.3.12
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -903,7 +903,7 @@ module Yast
       selinux_config.mode = @Settings["SELINUX_MODE"] unless @Settings["SELINUX_MODE"].to_s.empty?
 
       # Please, keep the unique id synced with the one used in normal installation
-      # See https://github.com/yast/yast-firewall/blob/c3ae49a1009dbf324fa3558dff6c5e147c495268/src/lib/y2firewall/clients/proposal.rb#L229-L230
+      # See https://github.com/yast/yast-installation/blob/7c19909e9700242209645cf12a4daffe1cd54194/src/lib/installation/clients/security_proposal.rb#L244-L247
       PackagesProposal.SetResolvables("SELinux", :pattern, selinux_config.needed_patterns)
     end
 


### PR DESCRIPTION
Change the `SELinux` resolvable unique id used in auto-installation to be consistent with the one used by normal installation.

https://github.com/yast/yast-installation/blob/7c19909e9700242209645cf12a4daffe1cd54194/src/lib/installation/clients/security_proposal.rb#L244-L247

---

Related to https://github.com/yast/yast-security/pull/88 and https://github.com/yast/yast-installation/pull/920