### PR TITLE
[SLE-15-SP2] Y2Security::Selinux does not write bootloader in insts-sys

### DIFF
--- a/package/yast2-security.changes
+++ b/package/yast2-security.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Mar  2 15:31:39 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Do not write bootloader in insts-sys (bsc#1182894).
+- 4.2.21
+
+-------------------------------------------------------------------
 Mon Mar  1 11:33:59 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
 - Change the SELinux resolvable unique id used in auto-installation

--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-security
-Version:        4.2.20
+Version:        4.2.21
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/lib/y2security/selinux.rb
+++ b/src/lib/y2security/selinux.rb
@@ -83,6 +83,7 @@ module Y2Security
 
     Yast.import "Bootloader"
     Yast.import "ProductFeatures"
+    Yast.import "Stage"
 
     # The current set mode
     #
@@ -201,7 +202,8 @@ module Y2Security
         relocate_autorelabel_file
       end
 
-      return true if Yast::Mode.installation
+      # in insts-sys bootloader write is done by bootloader_finish client
+      return true if Yast::Stage.initial
 
       log.info("Saving Bootloader configuration")
       Yast::Bootloader.Write
@@ -223,7 +225,7 @@ module Y2Security
     #                   the value of 'configurable' selinux settings in the control file when
     #                   running during installation or false if not present
     def configurable?
-      return true unless Yast::Mode.installation
+      return true unless Yast::Stage.initial
 
       product_feature_settings[:configurable] || false
     end
@@ -272,13 +274,13 @@ module Y2Security
       @config_file ||= CFA::Selinux.load
     end
 
-    # Sets the mode to the proposed one via `selinux_mode` global variable in the control file
+    # Sets the mode to the proposed one via selinux mode global variable in the control file
     #
     # @see #proposed_mode
     #
     # @return [Mode] disabled or found SELinux mode
     def make_proposal
-      return unless Yast::Mode.installation
+      return unless Yast::Stage.initial
 
       proposed_mode
     end
@@ -328,9 +330,9 @@ module Y2Security
     # @see https://jira.suse.com/browse/SLE-17307
     #
     # @return [Booelan] true if root fs will mounted as read only, SELinux is not disabled,
-    #                   and running in the installation mode; false otherwise
+    #                   and running in initial stage; false otherwise
     def relocate_autorelabel_file?
-      mode.to_sym != :disabled && Yast::Mode.installation && read_only_root_fs?
+      mode.to_sym != :disabled && Yast::Stage.initial && read_only_root_fs?
     end
 
     # Relocates the .autorelabel file from #{ROOT_AUTORELABEL_PATH} to #{ETC_AUTORELABEL_PATH} by

--- a/test/y2security/selinux_test.rb
+++ b/test/y2security/selinux_test.rb
@@ -57,7 +57,7 @@ describe Y2Security::Selinux do
   before do
     Yast::ProductFeatures.Import(product_features)
 
-    allow(Yast::Mode).to receive(:installation).and_return(installation_mode)
+    allow(Yast::Stage).to receive(:initial).and_return(installation_mode)
 
     allow(Yast::Bootloader).to receive(:kernel_param).with(:common, "security")
       .and_return(security_param)


### PR DESCRIPTION
Related to https://bugzilla.suse.com/show_bug.cgi?id=1182894, `Y2Security::Selinux` stop writing the bootloader in insts-sys by making use of `Yast::Stage.initial` instead of `Yast::Mode.installation`.

---

Originally sent by @jreidinger at https://github.com/yast/yast-security/pull/98 as part of https://github.com/yast/yast-installation/pull/923 and slightly related to https://github.com/yast/yast-security/pull/87