### PR TITLE
[SLE-15-SP2] Fix Security#Import ensuring SELinux patterns are set

### DIFF
--- a/package/yast2-security.changes
+++ b/package/yast2-security.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Mar  2 17:47:22 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Ensure defined SELinux patterns are set (bsc#1182543).
+- 4.2.21
+
+-------------------------------------------------------------------
 Tue Mar  2 15:31:39 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
 - Do not write bootloader in insts-sys (bsc#1182894).

--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-security
-Version:        4.2.21
+Version:        4.2.22
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -789,7 +789,10 @@ module Yast
         end
       end
 
+      set_selinux_patterns # Checking needed packages
+
       return true if settings == {}
+
       @modified = true
       tmpSettings = {}
       @Settings.each do |k, v|
@@ -812,7 +815,6 @@ module Yast
       end
 
       @Settings = tmpSettings
-      set_selinux_patterns # Checking needed packages
       true
     end
 


### PR DESCRIPTION
Linked to https://github.com/yast/yast-autoinstallation/pull/736, helps to solve the issue reported at https://bugzilla.suse.com/show_bug.cgi?id=1182543 ensuring that defined SELinux patterns are set when needed, no matter if imported security settings results in an empty collection.

Tested manually via `yupdate` using `SUSE-MicroOS-5.0-DVD-x86_64-Build85.5` and also applying changes proposed at https://github.com/yast/yast-autoinstallation/pull/736