### PR TITLE
Fix Security#Import ensuring SELinux patterns are set

### DIFF
--- a/package/yast2-security.changes
+++ b/package/yast2-security.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Mar  2 17:47:22 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Ensure defined SELinux patterns are set (bsc#1182543).
+- 4.3.14
+
+-------------------------------------------------------------------
 Tue Mar  2 15:31:39 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
 - Do not write bootloader in insts-sys (bsc#1182894).

--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-security
-Version:        4.3.13
+Version:        4.3.14
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -783,6 +783,8 @@ module Yast
         settings["PASSWD_USE_PWQUALITY"] = settings.delete("PASSWD_USE_CRACKLIB")
       end
 
+      set_selinux_patterns # Checking needed packages
+
       return true if settings == {}
 
       @modified = true
@@ -807,7 +809,6 @@ module Yast
       end
 
       @Settings = tmpSettings
-      set_selinux_patterns # Checking needed packages
       true
     end
 


### PR DESCRIPTION
Almost the same than #101 (this does not need changes in `yast-autoinstallation`), but for `master` branch.

It helps to avoid issues similar to https://bugzilla.suse.com/show_bug.cgi?id=1182543, ensuring that defined SELinux patterns are set when needed, no matter if imported security settings results in an empty collection.