### PR TITLE
[SLE-15-SP2] Fix duplicated version number in changelog

### DIFF
--- a/package/yast2-security.changes
+++ b/package/yast2-security.changes
@@ -2,7 +2,7 @@
 Tue Mar  2 17:47:22 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
 - Ensure defined SELinux patterns are set (bsc#1182543).
-- 4.2.21
+- 4.2.22
 
 -------------------------------------------------------------------
 Tue Mar  2 15:31:39 UTC 2021 - David Diaz <dgonzalez@suse.com>


### PR DESCRIPTION
Fixes wrong (and now duplicatd) `4.2.21` version number in the changelog introduced in #101  

 