### PR TITLE
[SLE-15-SP2] Make SELinux not configurable when running on WSL

### DIFF
--- a/package/yast2-security.changes
+++ b/package/yast2-security.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Mar  3 16:09:26 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Make SELinux not configurable when running on WSL (bsc#1182940)
+- 4.2.23
+
+-------------------------------------------------------------------
 Tue Mar  2 17:47:22 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
 - Ensure defined SELinux patterns are set (bsc#1182543).

--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-security
-Version:        4.2.22
+Version:        4.2.23
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/lib/y2security/selinux.rb
+++ b/src/lib/y2security/selinux.rb
@@ -81,6 +81,7 @@ module Y2Security
   class Selinux
     include Yast::Logger
 
+    Yast.import "Arch"
     Yast.import "Bootloader"
     Yast.import "ProductFeatures"
     Yast.import "Stage"
@@ -221,10 +222,12 @@ module Y2Security
 
     # Whether SELinux configuration can be changed
     #
-    # @return [Boolean] always true when running in installed system;
-    #                   the value of 'configurable' selinux settings in the control file when
-    #                   running during installation or false if not present
+    # @return [Boolean] false if running on Windows Subsystem for Linux (WSL);
+    #                   the value of 'configurable' selinux settings in the control file if
+    #                   running in initial stage (false if value is not present);
+    #                   always true when running in an installed system
     def configurable?
+      return false if Yast::Arch.is_wsl
       return true unless Yast::Stage.initial
 
       product_feature_settings[:configurable] || false

--- a/test/y2security/selinux_test.rb
+++ b/test/y2security/selinux_test.rb
@@ -38,6 +38,8 @@ describe Y2Security::Selinux do
     }
   end
 
+  let(:wsl) { false }
+
   let(:selinux_mode) { "enforcing" }
   let(:selinux_configurable) { false }
   let(:selinux_patterns) { nil }
@@ -57,6 +59,7 @@ describe Y2Security::Selinux do
   before do
     Yast::ProductFeatures.Import(product_features)
 
+    allow(Yast::Arch).to receive(:is_wsl).and_return(wsl)
     allow(Yast::Stage).to receive(:initial).and_return(installation_mode)
 
     allow(Yast::Bootloader).to receive(:kernel_param).with(:common, "security")
@@ -554,6 +557,14 @@ describe Y2Security::Selinux do
   end
 
   describe "#configurable?" do
+    context "when running in a WSL environment" do
+      let(:wsl) { true }
+
+      it "returns false" do
+        expect(subject.configurable?).to eq(false)
+      end
+    end
+
     context "when running in an installed system" do
       it "returns true" do
         expect(subject.configurable?).to eq(true)


### PR DESCRIPTION
Fix https://bugzilla.suse.com/show_bug.cgi?id=1182940 by making SELinux not configurable when running on [**W**indows **S**ubsystem for **L**inux](https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux). Thus, not calling to `Yast::Bootloader` for reading/writing boot kernel params.

> Since SELinux has to be configured via boot kernel params, it makes no
> sense to offer such feature when running on Windows Subsystem for
> Linux[1] becuase the system will be **booted via Windows, so Linux
> bootloader is useless here**[2].
> 
> [1] https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux
> [2] https://yastgithubio.readthedocs.io/en/latest/WSL/