### PR TITLE
[SLE-15-SP2] Do not set SELinux mode when it is not configurable

### DIFF
--- a/package/yast2-security.changes
+++ b/package/yast2-security.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Mar 18 11:43:42 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Do not set SELinux mode when it is not configurable (bsc#1182940)
+- 4.2.24
+
+-------------------------------------------------------------------
 Wed Mar  3 16:09:26 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
 - Make SELinux not configurable when running on WSL (bsc#1182940)

--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-security
-Version:        4.2.23
+Version:        4.2.24
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -452,9 +452,9 @@ module Yast
     #
     # @see Y2Security::Selinux
     def read_selinux_settings
-      return unless selinux_config.configurable?
+      return unless selinux.configurable?
 
-      @Settings["SELINUX_MODE"] = selinux_config.mode.id.to_s
+      @Settings["SELINUX_MODE"] = selinux.mode.id.to_s
 
       log.debug "SELINUX_MODE (after #{__callee__}): #{@Settings['SELINUX_MODE']}"
     end
@@ -568,8 +568,8 @@ module Yast
     #
     # @return true on success
     def write_selinux
-      selinux_config.mode = @Settings["SELINUX_MODE"]
-      selinux_config.save
+      selinux.mode = @Settings["SELINUX_MODE"]
+      selinux.save
     end
 
 
@@ -905,11 +905,11 @@ module Yast
 
     # Ensures needed patterns for SELinux, if any, will be installed
     def set_selinux_patterns
-      selinux_config.mode = @Settings["SELINUX_MODE"] unless @Settings["SELINUX_MODE"].to_s.empty?
+      selinux.mode = @Settings["SELINUX_MODE"] unless @Settings["SELINUX_MODE"].to_s.empty?
 
       # Please, keep the unique id synced with the one used in normal installation
       # See https://github.com/yast/yast-firewall/blob/c3ae49a1009dbf324fa3558dff6c5e147c495268/src/lib/y2firewall/clients/proposal.rb#L229-L230
-      PackagesProposal.SetResolvables("SELinux", :pattern, selinux_config.needed_patterns)
+      PackagesProposal.SetResolvables("SELinux", :pattern, selinux.needed_patterns)
     end
 
     # Sets @missing_mandatory_services honoring the systemd aliases
@@ -984,8 +984,8 @@ module Yast
   # Returns a SELinux configuration handler
   #
   # @return [Y2Security::Selinux] the SELinux config handler
-  def selinux_config
-    @selinux_config ||= Y2Security::Selinux.new
+  def selinux
+    @selinux ||= Y2Security::Selinux.new
   end
 
   # Checks if the service is allowed (i.e. not considered 'extra')

--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -452,6 +452,8 @@ module Yast
     #
     # @see Y2Security::Selinux
     def read_selinux_settings
+      return unless selinux_config.configurable?
+
       @Settings["SELINUX_MODE"] = selinux_config.mode.id.to_s
 
       log.debug "SELINUX_MODE (after #{__callee__}): #{@Settings['SELINUX_MODE']}"

--- a/test/levels_test.rb
+++ b/test/levels_test.rb
@@ -50,7 +50,7 @@ module Yast
         change_scr_root(File.join(DATA_PATH, "system"))
         stub_scr_write
         allow(Package).to receive(:Installed).with("systemd").and_return true
-        allow(Security.selinux_config).to receive(:save)
+        allow(Security.selinux).to receive(:save)
       end
 
       after do

--- a/test/security_test.rb
+++ b/test/security_test.rb
@@ -747,23 +747,45 @@ module Yast
 
     describe "#read_selinux_settings" do
       let(:mode) { double("Y2Security::Selinux::Mode", id: :enforcing) }
+      let(:configurable) { true }
 
       before do
         allow(subject.selinux_config).to receive(:mode).and_return(mode)
+        allow(subject.selinux_config).to receive(:configurable?).and_return(configurable)
       end
 
-      it "reads the selinux mode" do
-        expect(subject.selinux_config).to receive(:mode)
+      context "when SELinux is configurable" do
+        it "reads the selinux mode" do
+          expect(subject.selinux_config).to receive(:mode)
 
-        subject.read_selinux_settings
+          subject.read_selinux_settings
+        end
+
+        it "sets the SELINUX_MODE setting" do
+          expect(Security.Settings["SELINUX_MODE"]).to eq("")
+
+          Security.read_selinux_settings
+
+          expect(Security.Settings["SELINUX_MODE"]).to eq(mode.id.to_s)
+        end
       end
 
-      it "sets the SELINUX_MODE setting" do
-        expect(Security.Settings["SELINUX_MODE"]).to eq("")
+      context "when SELinux is not configurable" do
+        let(:configurable) { false }
 
-        Security.read_selinux_settings
+        it "does not read the selinux mode" do
+          expect(subject.selinux_config).to_not receive(:mode)
 
-        expect(Security.Settings["SELINUX_MODE"]).to eq(mode.id.to_s)
+          subject.read_selinux_settings
+        end
+
+        it "does not set the SELINUX_MODE setting" do
+          expect(Security.Settings["SELINUX_MODE"]).to eq("")
+
+          Security.read_selinux_settings
+
+          expect(Security.Settings["SELINUX_MODE"]).to eq("")
+        end
       end
     end
 

--- a/test/security_test.rb
+++ b/test/security_test.rb
@@ -244,18 +244,18 @@ module Yast
       let(:requested_mode) { "enforcing" }
 
       before do
-        allow(subject.selinux_config).to receive(:save)
+        allow(subject.selinux).to receive(:save)
         subject.Settings["SELINUX_MODE"] = requested_mode
       end
 
       it "sets the SELinux mode" do
-        expect(subject.selinux_config).to receive(:mode=).with(requested_mode)
+        expect(subject.selinux).to receive(:mode=).with(requested_mode)
 
         subject.write_selinux
       end
 
       it "saves the selinux config" do
-        expect(subject.selinux_config).to receive(:save)
+        expect(subject.selinux).to receive(:save)
 
         subject.write_selinux
       end
@@ -750,13 +750,13 @@ module Yast
       let(:configurable) { true }
 
       before do
-        allow(subject.selinux_config).to receive(:mode).and_return(mode)
-        allow(subject.selinux_config).to receive(:configurable?).and_return(configurable)
+        allow(subject.selinux).to receive(:mode).and_return(mode)
+        allow(subject.selinux).to receive(:configurable?).and_return(configurable)
       end
 
       context "when SELinux is configurable" do
         it "reads the selinux mode" do
-          expect(subject.selinux_config).to receive(:mode)
+          expect(subject.selinux).to receive(:mode)
 
           subject.read_selinux_settings
         end
@@ -774,7 +774,7 @@ module Yast
         let(:configurable) { false }
 
         it "does not read the selinux mode" do
-          expect(subject.selinux_config).to_not receive(:mode)
+          expect(subject.selinux).to_not receive(:mode)
 
           subject.read_selinux_settings
         end
@@ -819,7 +819,7 @@ module Yast
         Security.Settings["SYS_UID_MIN"] = 200
         Security.Settings["SYS_GID_MIN"] = 200
 
-        allow(subject.selinux_config).to receive(:needed_patterns).and_return(selinux_patterns)
+        allow(subject.selinux).to receive(:needed_patterns).and_return(selinux_patterns)
       end
 
       it "doest not touch current Settings if given settings are empty" do


### PR DESCRIPTION
### Problem

YaST Firstboot is crashing when running in Windows Subsystem for Linux (WSL) because a `Y2Security::Selinux#mode` calls that triggers a `Bootloader#Read`

See https://bugzilla.suse.com/show_bug.cgi?id=1182940

### Solution

Do not `#read_selinux_settings` when SElinux [is not configurable](https://github.com/yast/yast-security/blob/9d96d6e7a8ecc27caa910cc4e5ea7260926e4b3d/src/lib/y2security/selinux.rb#L223-L234).

### Tests

* Added unit tests
* Tested manually
  * Download the Windows 10 image and the appx from openQA.
  * [Enable WSL](https://docs.microsoft.com/en-us/windows/wsl/install-win10#manual-installation-steps)
  * [Import the certificate](https://social.msdn.microsoft.com/Forums/en-US/b9281639-5bb4-4064-a5dc-c769183d7d91/new-certificate-must-be-installed-for-this-app-package)
  * Install the appx.
  * Launch the appx takes you to a console. Start yast2-firstboot then: `/usr/lib/YaST2/startup/YaST2.call firstboot firstboot`.