### PR TITLE
Do not set SELinux mode when it is not configurable

### DIFF
--- a/package/yast2-security.changes
+++ b/package/yast2-security.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Mar 18 11:43:42 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Do not set SELinux mode when it is not configurable (bsc#1182940)
+- 4.3.16
+
+-------------------------------------------------------------------
 Wed Mar  3 16:09:26 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
 - Make SELinux not configurable when running on WSL (bsc#1182940)

--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-security
-Version:        4.3.15
+Version:        4.3.16
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -375,7 +375,9 @@ module Yast
     #
     # @see Y2Security::Selinux
     def read_selinux_settings
-      @Settings["SELINUX_MODE"] = selinux_config.mode.id.to_s
+      return unless selinux.configurable?
+
+      @Settings["SELINUX_MODE"] = selinux.mode.id.to_s
 
       log.debug "SELINUX_MODE (after #{__callee__}): #{@Settings['SELINUX_MODE']}"
     end
@@ -548,8 +550,8 @@ module Yast
     #
     # @return true on success
     def write_selinux
-      selinux_config.mode = @Settings["SELINUX_MODE"]
-      selinux_config.save
+      selinux.mode = @Settings["SELINUX_MODE"]
+      selinux.save
     end
 
     # Write settings related to PAM behavior
@@ -901,11 +903,11 @@ module Yast
 
     # Ensures needed patterns for SELinux, if any, will be installed
     def set_selinux_patterns
-      selinux_config.mode = @Settings["SELINUX_MODE"] unless @Settings["SELINUX_MODE"].to_s.empty?
+      selinux.mode = @Settings["SELINUX_MODE"] unless @Settings["SELINUX_MODE"].to_s.empty?
 
       # Please, keep the unique id synced with the one used in normal installation
       # See https://github.com/yast/yast-installation/blob/7c19909e9700242209645cf12a4daffe1cd54194/src/lib/installation/clients/security_proposal.rb#L244-L247
-      PackagesProposal.SetResolvables("SELinux", :pattern, selinux_config.needed_patterns)
+      PackagesProposal.SetResolvables("SELinux", :pattern, selinux.needed_patterns)
     end
 
     # Sets @missing_mandatory_services honoring the systemd aliases
@@ -981,8 +983,8 @@ module Yast
   # Returns a SELinux configuration handler
   #
   # @return [Y2Security::Selinux] the SELinux config handler
-  def selinux_config
-    @selinux_config ||= Y2Security::Selinux.new
+  def selinux
+    @selinux ||= Y2Security::Selinux.new
   end
 
   # Checks if the service is allowed (i.e. not considered 'extra')

--- a/test/levels_test.rb
+++ b/test/levels_test.rb
@@ -50,7 +50,7 @@ module Yast
         change_scr_root(File.join(DATA_PATH, "system"))
         stub_scr_write
         allow(Package).to receive(:Installed).with("systemd").and_return true
-        allow(Security.selinux_config).to receive(:save)
+        allow(Security.selinux).to receive(:save)
       end
 
       after do


### PR DESCRIPTION
The same than https://github.com/yast/yast-security/pull/106, but for `master` branch.

> YaST Firstboot is crashing when running in Windows Subsystem for Linux (WSL) because a `Y2Security::Selinux#mode` calls that triggers a `Bootloader#Read`
>

![selinux_bootloader_wsl](https://user-images.githubusercontent.com/1691872/111627209-be4edf80-87e6-11eb-8633-47b01b8022ec.png)


Related links

* https://bugzilla.suse.com/show_bug.cgi?id=1182940
* https://openqa.suse.de/tests/5673243#step/firstrun/16



For manual testing:

>   * Download the Windows 10 image and the appx from openQA.
>   * [Enable WSL](https://docs.microsoft.com/en-us/windows/wsl/install-win10#manual-installation-steps)
>   * [Import the certificate](https://social.msdn.microsoft.com/Forums/en-US/b9281639-5bb4-4064-a5dc-c769183d7d91/new-certificate-must-be-installed-for-this-app-package)
>   * Install the appx.
>   * Launch the appx takes you to a console. Start yast2-firstboot then: `/usr/lib/YaST2/startup/YaST2.call firstboot firstboot`.