### PR TITLE
bsc#1184131: use /etc/login.defs for shadow configuration

### DIFF
--- a/package/yast2-security.changes
+++ b/package/yast2-security.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Apr 12 20:29:34 UTC 2021 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Write shadow configuration to /etc/login.defs ignoring the
+  /etc/login.defs.d (bsc#1184131).
+- 4.2.25
+
+-------------------------------------------------------------------
 Thu Mar 18 11:43:42 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
 - Do not set SELinux mode when it is not configurable (bsc#1182940)

--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -36,8 +36,8 @@ BuildRequires:  yast2-devtools >= 4.2.2
 BuildRequires:  yast2-bootloader
 BuildRequires:  rubygem(%{rb_default_ruby_abi}:yast-rake) >= 0.2.5
 BuildRequires:  rubygem(%{rb_default_ruby_abi}:rspec)
-# CFA::SysctlConfig
-BuildRequires:  yast2 >= 4.2.66
+# Removed ShadowConfig class; LoginDefs::new default values
+BuildRequires:  yast2 >= 4.2.93
 # CFA::Selinux
 BuildRequires:  augeas-lenses
 # Y2Storage::StorageManager

--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-security
-Version:        4.2.24
+Version:        4.2.25
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -28,7 +28,7 @@
 require "yast"
 require "yast2/systemd/service"
 require "cfa/sysctl_config"
-require "cfa/shadow_config"
+require "cfa/login_defs"
 require "yaml"
 require "security/ctrl_alt_del_config"
 require "security/display_manager"
@@ -976,8 +976,9 @@ module Yast
       sysctl_config.public_send(SYSCTL_KEY_TO_METH[key].to_s + "=", value)
     end
 
+    # Rely on /etc/login.defs in SLE 15 SP2 (see bsc#1184131).
     def shadow_config
-      @shadow_config ||= CFA::ShadowConfig.load
+      @shadow_config ||= CFA::LoginDefs.load
     end
   end
 

--- a/test/levels_test.rb
+++ b/test/levels_test.rb
@@ -24,7 +24,7 @@ module Yast
     let(:tester) { LevelsTester.new }
     subject(:settings) { tester.Levels }
 
-    let(:shadow_config) { CFA::LoginDefs.new }
+    let(:shadow_config) { CFA::LoginDefs.new(file_path: "/etc/login.defs") }
     let(:sysctl_config) { CFA::SysctlConfig.new }
 
     before do

--- a/test/levels_test.rb
+++ b/test/levels_test.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env rspec
 
 require_relative 'test_helper'
-require "cfa/shadow_config"
+require "cfa/login_defs"
 require "cfa/sysctl_config"
 
 module Yast
@@ -24,12 +24,12 @@ module Yast
     let(:tester) { LevelsTester.new }
     subject(:settings) { tester.Levels }
 
-    let(:shadow_config) { CFA::ShadowConfig.new }
+    let(:shadow_config) { CFA::LoginDefs.new }
     let(:sysctl_config) { CFA::SysctlConfig.new }
 
     before do
       tester
-      allow(CFA::ShadowConfig).to receive(:load).and_return(shadow_config)
+      allow(CFA::LoginDefs).to receive(:load).and_return(shadow_config)
       allow(shadow_config).to receive(:save)
       allow(Security).to receive(:sysctl_config).and_return(sysctl_config)
       allow(sysctl_config).to receive(:conflict?)

--- a/test/security_test.rb
+++ b/test/security_test.rb
@@ -37,14 +37,14 @@ module Yast
 
   describe Security do
     let(:sysctl_config) { CFA::SysctlConfig.new }
-    let(:shadow_config) { CFA::ShadowConfig.new }
+    let(:login_defs) { CFA::LoginDefs.new }
     let(:bash_path) { Yast::Path.new(".target.bash") }
 
     before do
       allow(CFA::SysctlConfig).to receive(:new).and_return(sysctl_config)
       allow(sysctl_config).to receive(:save)
-      allow(CFA::ShadowConfig).to receive(:load).and_return(shadow_config)
-      allow(shadow_config).to receive(:save)
+      allow(CFA::LoginDefs).to receive(:load).and_return(login_defs)
+      allow(login_defs).to receive(:save)
       Security.main
     end
 
@@ -234,8 +234,8 @@ module Yast
       end
 
       it "writes login.defs configuration" do
-        expect(shadow_config).to receive(:fail_delay=).with("10")
-        expect(shadow_config).to receive(:save)
+        expect(login_defs).to receive(:fail_delay=).with("10")
+        expect(login_defs).to receive(:save)
         Security.write_shadow_config
       end
     end
@@ -736,7 +736,7 @@ module Yast
 
     describe "#read_shadow_config" do
       before do
-        allow(shadow_config).to receive(:fail_delay).and_return("10")
+        allow(login_defs).to receive(:fail_delay).and_return("10")
       end
 
       it "reads login.defs configuration" do

--- a/test/security_test.rb
+++ b/test/security_test.rb
@@ -37,7 +37,7 @@ module Yast
 
   describe Security do
     let(:sysctl_config) { CFA::SysctlConfig.new }
-    let(:login_defs) { CFA::LoginDefs.new }
+    let(:login_defs) { CFA::LoginDefs.new(file_path: "/etc/login.defs") }
     let(:bash_path) { Yast::Path.new(".target.bash") }
 
     before do


### PR DESCRIPTION
Adapts yast2-security to use the `CFA::LoginDefs` class instead of `CFA::ShadowConfig`. Please, find the rationale in https://github.com/yast/yast-yast2/pull/1152.