### PR TITLE
Read without exceptions

### DIFF
--- a/package/yast2-security.changes
+++ b/package/yast2-security.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jul 14 13:51:18 UTC 2021 - José Iván López González <jlopez@suse.com>
+
+- Add Security#SafeRead to allow to detect read errors when calling
+  it from perl modules (releated to bsc#1177183).
+- 4.3.17
+
+-------------------------------------------------------------------
 Thu Mar 18 11:43:42 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
 - Do not set SELinux mode when it is not configurable (bsc#1182940)

--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-security
-Version:        4.3.16
+Version:        4.3.17
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -463,7 +463,9 @@ module Yast
     end
 
     # Read all security settings
-    # @return true on success
+    #
+    # @raise [Exception] if there is an issue while reading the settings
+    # @return [Boolean] true on success
     def Read
       @Settings = {}
       @modified = false
@@ -495,6 +497,23 @@ module Yast
 
       log.info "Settings after Read: #{@Settings}"
       true
+    end
+
+    # Reads all security settings without raising exceptions
+    #
+    # This method saves any error produced while reading the settings instead of raising an
+    # exception. This is needed when the module is used from a perl module because the exceptions
+    # are not propagated to perl code.
+    #
+    # @return [Boolean] true on success. When false, the error message can be check by calling to
+    #   Security#read_error.
+    def SafeRead
+      @read_error = nil
+      self.Read
+      true
+    rescue StandardError => e
+      @read_error = e.message
+      false
     end
 
     # Write the value of ctrl-alt-delete behavior
@@ -888,11 +907,13 @@ module Yast
     publish :variable => :modified, :type => "boolean"
     publish :variable => :proposal_valid, :type => "boolean"
     publish :variable => :write_only, :type => "boolean"
+    publish :variable => :read_error, :type => "string"
     publish :function => :GetModified, :type => "boolean ()"
     publish :function => :SetModified, :type => "void ()"
     publish :function => :Modified, :type => "boolean ()"
     publish :function => :ReadServiceSettings, :type => "void ()"
     publish :function => :Read, :type => "boolean ()"
+    publish :function => :SafeRead, :type => "boolean ()"
     publish :function => :Write, :type => "boolean ()"
     publish :function => :Import, :type => "boolean (map)"
     publish :function => :Export, :type => "map ()"

--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -35,7 +35,7 @@ require "security/display_manager"
 require "y2security/selinux"
 
 module Yast
-  class SecurityClass < Module
+  class SecurityClass < Module # rubocop:disable Metrics/ClassLength
     DEFAULT_ENCRYPT_METHOD = "sha512".freeze
     private_constant :DEFAULT_ENCRYPT_METHOD
 

--- a/test/security_test.rb
+++ b/test/security_test.rb
@@ -702,6 +702,46 @@ module Yast
       end
     end
 
+    describe "#SafeRead" do
+      it "reads settings" do
+        expect(Security).to receive(:Read).and_return(true)
+
+        Security.SafeRead
+      end
+
+      context "when there is no error reading the settings" do
+        before do
+          allow(Security).to receive(:Read).and_return(true)
+        end
+
+        it "returns true" do
+          expect(Security.SafeRead).to eq(true)
+        end
+
+        it "does not store a read error" do
+          Security.SafeRead
+
+          expect(Security.read_error).to be_nil
+        end
+      end
+
+      context "when there is an error reading the settings" do
+        before do
+          allow(Security).to receive(:Read).and_raise "read error"
+        end
+
+        it "returns false" do
+          expect(Security.SafeRead).to eq(false)
+        end
+
+        it "stores a read error" do
+          Security.SafeRead
+
+          expect(Security.read_error).to eq("read error")
+        end
+      end
+    end
+
     describe "#Import" do
       let(:selinux_patterns) { ["example-selinux-patterns"] }
 


### PR DESCRIPTION
## Problem

The `Security` module offers a `Read` method which raises an exception if reading the settings fails (e.g., parsing error, file does not exist, etc). But that exceptions are lost when the `Security#Read` is called from a perl module like `Users.pm`. As result, the perl code has no way to check if there was an error while reading the security settings.

* Related to https://bugzilla.suse.com/show_bug.cgi?id=1177183
* Needed for https://github.com/yast/yast-users/pull/317


## Solution 

Add a new method `Security#SafeRead` which avoids to raise exceptions. It stores the error message when reading the settings fails.
