### PR TITLE
Pass selinux=1 boot parameter when not disabled explicitly

### DIFF
--- a/package/yast2-security.changes
+++ b/package/yast2-security.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Dec 29 11:47:15 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Added back the selinux boot parameter when selinux is selected
+  and not disabled in order to switch on SELinux (jsc#SLE-22069)
+- 4.4.3
+
+-------------------------------------------------------------------
 Wed Dec 22 23:06:57 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Add support for selecting and configuring the desired Linux 

--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-security
-Version:        4.4.2
+Version:        4.4.3
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/lib/y2security/lsm/selinux.rb
+++ b/src/lib/y2security/lsm/selinux.rb
@@ -402,7 +402,7 @@ module Y2Security
           @name = name
           @options = {
             "lsm"       => "selinux",
-            "selinux"   => disable   ? "0" : :missing,
+            "selinux"   => disable   ? "0" : "1",
             "enforcing" => enforcing ? "1" : :missing
           }
         end


### PR DESCRIPTION
Bring back the `selinux=1` boot parameter when SELinux is selected and it is not disabled explicitly. Related to #115 