### PR TITLE
Do not propose any Linux Security Module if declared as not configurable

### DIFF
--- a/package/yast2-security.changes
+++ b/package/yast2-security.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Tue Jan  4 12:06:48 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
+
+- Related to jsc#SLE-22069:
+  - Autoyast LSM section: added "selectable" option to the section
+  - Do not propose a default LSM configuration when it is declared
+    as not configurable in the control file or AutoYaST
+- 4.4.4
+
+-------------------------------------------------------------------
 Wed Dec 29 11:47:15 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Added back the selinux boot parameter when selinux is selected

--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-security
-Version:        4.4.3
+Version:        4.4.4
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/autoyast-rnc/security.rnc
+++ b/src/autoyast-rnc/security.rnc
@@ -130,23 +130,29 @@ y2_security =
   | lsm
 security = element security { MAP, y2_security* }
 
-configurable = element configurable  { BOOLEAN }
-selectable = element selectable  { BOOLEAN }
+## Whether the module can be proposed/configured during installation
+lsm_configurable = element configurable  { BOOLEAN }
+## Whether the module can be selected during installation
+lsm_selectable = element selectable  { BOOLEAN }
+## Space-separated list of required/suggested patterns for the selected module
+lsm_patterns =  element patterns { text }
 
 lsm = element lsm { MAP,
   (
     lsm_select? &
-    configurable? &
+    lsm_configurable? &
+    lsm_selectable? &
     selinux? &
     apparmor?
   )
 }
 
-lsm_select = element select { STRING }
+# Linux Security Major Module to be activated after installation
+lsm_select = element select { "apparmor" | "selinux" | "none" }
 lsm_module =
-  configurable
-  | selectable
-  | element patterns { STRING }
+  lsm_configurable
+  | lsm_selectable
+  | lsm_patterns
 
 apparmor = element apparmor { MAP,
   lsm_module*

--- a/src/lib/y2security/lsm/config.rb
+++ b/src/lib/y2security/lsm/config.rb
@@ -51,6 +51,7 @@ module Y2Security
       # Select the LSM to be used based in the one defined in the control file using apparmor as
       # fallback in case that no one is selected
       def propose_default
+        return unless configurable?
         log.info("The settings are #{product_feature_settings.inspect}")
         selected = product_feature_settings.fetch(:select, "apparmor")
 

--- a/src/lib/y2security/lsm/config.rb
+++ b/src/lib/y2security/lsm/config.rb
@@ -52,6 +52,7 @@ module Y2Security
       # fallback in case that no one is selected
       def propose_default
         return unless configurable?
+
         log.info("The settings are #{product_feature_settings.inspect}")
         selected = product_feature_settings.fetch(:select, "apparmor")
 
@@ -141,7 +142,7 @@ module Y2Security
         return @configurable unless @configurable.nil?
         return false if Yast::Arch.is_wsl
 
-        @configurable = product_feature_settings[:configurable] || false
+        @configurable = product_feature_settings.fetch(:configurable, true)
       end
 
       # Returns the values for the LSM setting from the product features

--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -932,6 +932,8 @@ module Yast
       section = Y2Security::AutoinstProfile::SecuritySection.new_from_hashes(settings)
       Y2Security::Autoinst::LSMConfigReader.new(section.lsm).read
 
+      return unless lsm_config.configurable?
+
       PackagesProposal.SetResolvables("LSM", :pattern, lsm_config.needed_patterns)
     end
 

--- a/test/security_test.rb
+++ b/test/security_test.rb
@@ -720,13 +720,23 @@ module Yast
       end
 
       context "when a specific Linux Security Module is selected" do
-        it "sets resolvables for needed patterns" do
-          allow_any_instance_of(Y2Security::LSM::Base).to receive(:needed_patterns)
-            .and_return(selinux_patterns)
-          expect(Yast::PackagesProposal).to receive(:SetResolvables)
-            .with(anything, :pattern, selinux_patterns)
-  
-          Security.Import("selinux_mode" => "permissive")
+        context "and LSM is configurable" do
+          it "sets resolvables for needed patterns" do
+            allow_any_instance_of(Y2Security::LSM::Base).to receive(:needed_patterns)
+              .and_return(selinux_patterns)
+            expect(Yast::PackagesProposal).to receive(:SetResolvables)
+              .with(anything, :pattern, selinux_patterns)
+
+            Security.Import("selinux_mode" => "permissive")
+          end
+        end
+
+        context "and LSM is declared as no configurable" do
+          it "does not touch resolvables" do
+            expect(Yast::PackagesProposal).to_not receive(:SetResolvables)
+
+            Security.Import("lsm" => { "configurable" => false })
+          end
         end
       end
 

--- a/test/y2security/lsm/config_test.rb
+++ b/test/y2security/lsm/config_test.rb
@@ -174,16 +174,26 @@ describe Y2Security::LSM::Config do
   end
 
   describe "#propose_default" do
-    it "selects the LSM to be used based on the control file" do
-      expect { subject.propose_default }.to change { subject.selected&.id }.from(nil).to(:selinux)
+    context "when Linux Security module is declared as configurable in the control file" do
+      it "selects the LSM to be used based on the control file" do
+        expect { subject.propose_default }.to change { subject.selected&.id }.from(nil).to(:selinux)
+      end
+
+      context "when no default LSM is declared in the control file" do
+        let(:lsm_section) { { "configurable" => lsm_configurable } }
+
+        it "fallbacks to :apparmor" do
+          expect { subject.propose_default }
+            .to change { subject.selected&.id }.from(nil).to(:apparmor)
+        end
+      end
     end
 
-    context "when no default LSM is declared in the control file" do
-      let(:lsm_section) { { "configurable" => lsm_configurable } }
+    context "when Linux Security module is not declared as configurable in the control file" do
+      let(:lsm_configurable) { false }
 
-      it "fallbacks to :apparmor" do
-        expect { subject.propose_default }
-          .to change { subject.selected&.id }.from(nil).to(:apparmor)
+      it "does not select any module by default" do
+        expect { subject.propose_default }.to_not(change { subject.selected })
       end
     end
   end


### PR DESCRIPTION
In case that the **Linux Security Module** should not be configured during the installation then we should not select any module at all in order to not write the boot parameters.

Related to #115

After discussing the current behavior with @dgdavid it probably makes sense to have also a differentiation between **selectable** and **configurable** for the **LSM** config, adding the **selectable** tag also there.

In case that LSM is not selectable then the widget and probably the proposal could be hidden but we could select a default LSM in case of configurable. If it is marked as no configurable then it will be hidden and also skipped completely.