### PR TITLE
Use security

### DIFF
--- a/package/yast2-security.changes
+++ b/package/yast2-security.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Jan  7 12:37:08 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
+
+- Do not use the 'lsm' kernel boot parameter by now as it could
+  need other modules to be pecified like the integrity one
+  (bsc#1194332).
+- 4.4.5
+
+-------------------------------------------------------------------
 Tue Jan  4 12:06:48 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
 - Related to jsc#SLE-22069:
@@ -17,7 +25,7 @@ Wed Dec 29 11:47:15 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 -------------------------------------------------------------------
 Wed Dec 22 23:06:57 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
-- Add support for selecting and configuring the desired Linux 
+- Add support for selecting and configuring the desired Linux
   Security Module (jsc#SLE-22069)
 - 4.4.2
 

--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-security
-Version:        4.4.4
+Version:        4.4.5
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/lib/y2security/lsm/app_armor.rb
+++ b/src/lib/y2security/lsm/app_armor.rb
@@ -40,7 +40,7 @@ module Y2Security
 
       # @see Base#kernel_params
       def kernel_params
-        { "lsm" => "apparmor" }
+        { "security" => "apparmor" }
       end
     end
   end

--- a/src/lib/y2security/lsm/selinux.rb
+++ b/src/lib/y2security/lsm/selinux.rb
@@ -401,7 +401,7 @@ module Y2Security
           @id = id.to_sym
           @name = name
           @options = {
-            "lsm"       => "selinux",
+            "security"  => "selinux",
             "selinux"   => disable   ? "0" : "1",
             "enforcing" => enforcing ? "1" : :missing
           }

--- a/test/y2security/lsm/app_armor_test.rb
+++ b/test/y2security/lsm/app_armor_test.rb
@@ -39,8 +39,8 @@ describe Y2Security::LSM::AppArmor do
       expect(subject.kernel_params).to be_a(Hash)
     end
 
-    it "includes the key 'lsm' with the 'apparmor' value" do
-      expect(subject.kernel_params).to include("lsm" => "apparmor")
+    it "includes the key 'security' with the 'apparmor' value" do
+      expect(subject.kernel_params).to include("security" => "apparmor")
     end
   end
 end

--- a/test/y2security/lsm/selinux_test.rb
+++ b/test/y2security/lsm/selinux_test.rb
@@ -678,7 +678,7 @@ describe Y2Security::LSM::Selinux::Mode do
     let(:mode) { described_class.find(:disabled) }
 
     it "returns the mode options" do
-      expect(mode.options).to a_hash_including("lsm", "selinux", "enforcing")
+      expect(mode.options).to a_hash_including("security", "selinux", "enforcing")
     end
   end
 end


### PR DESCRIPTION
## Problem

As it seems that we need to specify also the **integrity** module in order to be able to use the **Linux Integrity Measurement Architecture (IMA)** subsystem it has been decided that by now it is preferable to continue using the **security** boot parameter instead of the **lsm** one.

See https://github.com/openSUSE/kernel-source/commit/953db3507d62938038cd5f2d4bbe7fd0cb3d3763

- https://bugzilla.suse.com/show_bug.cgi?id=1194332


**Note**: We could write **lsm=integrity,apparmor** when **apparmor** is selected having the same value we have by default but that looks strange and we should add it in case we allow to select a list of modules to be set during installation.
