### PR TITLE
Fix security auto requirement

### DIFF
--- a/package/yast2-security.changes
+++ b/package/yast2-security.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jan 10 10:08:44 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
+
+- Fix security_auto client selinux requirement (bsc#1194449)
+- 4.4.6
+
+-------------------------------------------------------------------
 Fri Jan  7 12:37:08 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
 - Do not use the 'lsm' kernel boot parameter by now as it could

--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-security
-Version:        4.4.5
+Version:        4.4.6
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/clients/security_auto.rb
+++ b/src/clients/security_auto.rb
@@ -30,7 +30,7 @@
 # goes through the configuration and return the setting.
 # Does not do any changes to the configuration.
 
-require "y2security/selinux"
+require "y2security/lsm"
 
 # @param function to execute
 # @param map/list of security settings
@@ -86,7 +86,7 @@ module Yast
 
         # Checking value semantic
         if @param.key?("selinux_mode")
-          selinux_values = Y2Security::Selinux.new.modes.map { |m| m.id.to_s }
+          selinux_values = Y2Security::LSM::Selinux.new.modes.map { |m| m.id.to_s }
           if !selinux_values.include?(@param["selinux_mode"])
             Yast::AutoInstall.issues_list.add(
               :invalid_value,


### PR DESCRIPTION
## Problem

The requirement was not updated since we moved the **SELinux** class under **LSM** (related to #115)

- https://bugzilla.suse.com/show_bug.cgi?id=1194449

## Solution

Fix the dependency

## Tests

Tested manually but we probably should add a unit test for the auto client **ASAP**.