### PR TITLE
Autoyast LSM section: Added 'none' subsection allowing to mark the module as not selectable

### DIFF
--- a/package/yast2-security.changes
+++ b/package/yast2-security.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Jan 11 00:06:20 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
+
+Related to jsc#SLE-22069:
+  - Autoyast LSM section: added "none" section in order to mark it
+    as not selectable during the installation.
+- 4.4.7
+
+-------------------------------------------------------------------
 Mon Jan 10 10:08:44 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
 - Fix security_auto client selinux requirement (bsc#1194449)

--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-security
-Version:        4.4.6
+Version:        4.4.7
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/autoyast-rnc/security.rnc
+++ b/src/autoyast-rnc/security.rnc
@@ -142,6 +142,7 @@ lsm = element lsm { MAP,
     lsm_select? &
     lsm_configurable? &
     lsm_selectable? &
+    none? &
     selinux? &
     apparmor?
   )
@@ -153,6 +154,10 @@ lsm_module =
   lsm_configurable
   | lsm_selectable
   | lsm_patterns
+
+none = element none { MAP,
+  lsm_selectable?
+}
 
 apparmor = element apparmor { MAP,
   lsm_module*


### PR DESCRIPTION
It will allow to hide the option in case of not wanted:

```xml
<?xml version="1.0"?>
<!DOCTYPE profile>
<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
  <security>
  <lsm>
    <select>apparmor</select>
    <configurable config:type="boolean">true</configurable>
    <none>
      <!-- The option will not be available in the confirmation proposal for selecting it -->
      <selectable config:type="boolean">false</selectable>
    </none>
  </lsm>
  </security>	
</profile>
```

related to #115