### PR TITLE
Ay fixes

### DIFF
--- a/package/yast2-security.changes
+++ b/package/yast2-security.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Jan 24 09:45:55 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
+
+- Related to jsc#SLE-22069:
+  - Fix import of 'none' and 'apparmor' options from the profile
+    when declared
+- 4.4.8
+
+-------------------------------------------------------------------
 Tue Jan 11 00:06:20 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
 Related to jsc#SLE-22069:

--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-security
-Version:        4.4.7
+Version:        4.4.8
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/lib/y2security/autoinst/lsm_config_reader.rb
+++ b/src/lib/y2security/autoinst/lsm_config_reader.rb
@@ -50,14 +50,16 @@ module Y2Security
     private
 
       def configure_supported_modules
-        [:selinux, :apparmor].each do |id|
+        [:selinux, :apparmor, :none].each do |id|
           lsm_module = config.public_send(id)
           @module_section = section.public_send(id)
           next unless module_section
 
           assign(lsm_module, :mode) if id == :selinux
-          assign(lsm_module, :configurable)
           assign(lsm_module, :selectable)
+          next if id == :none
+
+          assign(lsm_module, :configurable)
           assign(lsm_module, :patterns)
         end
       end

--- a/src/lib/y2security/autoinst_profile/lsm_section.rb
+++ b/src/lib/y2security/autoinst_profile/lsm_section.rb
@@ -30,6 +30,9 @@ module Y2Security
     #   <apparmor>
     #     <selectable config:type="boolean">false</selectable>
     #   </apparmor>
+    #   <none>
+    #     <selectable config:type="boolean">false</selectable>
+    #   </none>
     #   <selinux>
     #     <mode>permissive</mode>
     #     <configurable config:type="boolean">true</configurable>
@@ -42,7 +45,8 @@ module Y2Security
           { name: :select },
           { name: :configurable },
           { name: :selinux },
-          { name: :apparmor }
+          { name: :apparmor },
+          { name: :none }
         ]
       end
 
@@ -61,7 +65,8 @@ module Y2Security
         super
 
         @selinux = SelinuxSection.new_from_hashes(hash["selinux"], self) if hash["selinux"]
-        @apparmor = ApparmorSection.new_from_hashes(hash["selinux"], self) if hash["apparmor"]
+        @apparmor = ApparmorSection.new_from_hashes(hash["apparmor"], self) if hash["apparmor"]
+        @none = ApparmorSection.new_from_hashes(hash["none"], self) if hash["none"]
 
         nil
       end

--- a/test/y2security/autoinst/lsm_config_reader_test.rb
+++ b/test/y2security/autoinst/lsm_config_reader_test.rb
@@ -33,6 +33,14 @@ describe Y2Security::Autoinst::LSMConfigReader do
           "configurable" => false,
           "selectable"   => true,
           "patterns"     => "selinux_pattern"
+        },
+        "apparmor"     => {
+          "configurable" => true,
+          "selectable"   => false,
+          "patterns"     => "apparmor_pattern"
+        },
+        "none"         => {
+          "selectable" => false
         }
       }
     }
@@ -58,6 +66,15 @@ describe Y2Security::Autoinst::LSMConfigReader do
         expect(selinux.configurable).to eql(false)
         expect(selinux.selectable).to eql(true)
         expect(selinux.needed_patterns).to eql(["selinux_pattern"])
+
+        apparmor = lsm.apparmor
+
+        expect(apparmor.configurable).to eql(true)
+        expect(apparmor.selectable).to eql(false)
+        expect(apparmor.needed_patterns).to eql(["apparmor_pattern"])
+
+        none = lsm.none
+        expect(none.selectable).to eql(false)
       end
     end
   end


### PR DESCRIPTION
## Problem

AutoYaST options for **'apparmor'** and **'none'** sections are not handled / parsed correctly.

https://trello.com/c/0KpnKW6N/2754-8-feature-shouldhave-unify-selinux-and-apparmor-solution-in-the-installation-summary