### PR TITLE
Stop using the 'lsm' kernel boot parameter

### DIFF
--- a/package/yast2-security.changes
+++ b/package/yast2-security.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Feb 22 08:08:56 UTC 2022 - David Diaz <dgonzalez@suse.com>
+
+- Stop using 'lsm' kernel boot parameter even for the
+  "None" Major Linux Security Module (bsc#1194332, bsc#1196274).
+- 4.4.12
+
+-------------------------------------------------------------------
 Fri Feb  4 09:19:19 UTC 2022 - Knut Anderssen <kanderssen@suse.com>
 
 - Fixed Export unit test (related to jsc#SLE-22069).

--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-security
-Version:        4.4.11
+Version:        4.4.12
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/lib/y2security/lsm/none.rb
+++ b/src/lib/y2security/lsm/none.rb
@@ -40,7 +40,7 @@ module Y2Security
 
       # @see Base#kernel_params
       def kernel_params
-        { "lsm" => "" }
+        { "security" => "" }
       end
 
       # @see Base#kernel_options

--- a/test/y2security/lsm/none_test.rb
+++ b/test/y2security/lsm/none_test.rb
@@ -39,8 +39,8 @@ describe Y2Security::LSM::None do
       expect(subject.kernel_params).to be_a(Hash)
     end
 
-    it "includes the key 'lsm' with an empty string as the value" do
-      expect(subject.kernel_params).to include("lsm" => "")
+    it "includes the key 'security' with an empty string as the value" do
+      expect(subject.kernel_params).to include("security" => "")
     end
   end
 


### PR DESCRIPTION
Even for the _None_ option, which was forgotten when going back from the recommended `lsm` to the `security` one. See https://github.com/yast/yast-security/pull/118.

This should fix https://bugzilla.suse.com/show_bug.cgi?id=1196274