### PR TITLE
Do not crash if reading active LSM modules returns nil

### DIFF
--- a/package/yast2-security.changes
+++ b/package/yast2-security.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Aug 23 08:41:45 UTC 2022 - David Diaz <dgonzalez@suse.com>
+
+- Do not crash when reading active LSM modules returns nil
+  (related to jsc#SLE-22069)
+- 4.5.1
+
+-------------------------------------------------------------------
 Wed Apr 06 13:24:58 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Bump version to 4.5.0 (bsc#1198109)

--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-security
-Version:        4.5.0
+Version:        4.5.1
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/lib/y2security/lsm/config.rb
+++ b/src/lib/y2security/lsm/config.rb
@@ -126,7 +126,7 @@ module Y2Security
       def active
         return [] unless Yast::Stage.normal
 
-        modules = Yast::SCR.Read(Yast.path(".target.string"), RUNNING_PATH)
+        modules = Yast::SCR.Read(Yast.path(".target.string"), RUNNING_PATH).to_s
         modules.split(",").each_with_object([]) do |name, result|
           supported_module = supported.find { |m| m.id.to_s == name }
           result << supported_module if supported_module

--- a/test/y2security/lsm/config_test.rb
+++ b/test/y2security/lsm/config_test.rb
@@ -66,6 +66,14 @@ describe Y2Security::LSM::Config do
       expect(active.first.id).to eql(:selinux)
     end
 
+    context "when there are no active LSM modules" do
+      let(:active_modules) { nil }
+
+      it "returns an empty array" do
+        expect(subject.active).to eq([])
+      end
+    end
+
     context "when no supported LSM is active" do
       let(:active_modules) { "lockdown,capabilities,tomoyo" }
 


### PR DESCRIPTION
Same as https://github.com/yast/yast-security/pull/129, but for master.