### PR TITLE
Enable/disable the ssg-apply service according to the security policies

### DIFF
--- a/src/lib/y2security/clients/security_policy_proposal.rb
+++ b/src/lib/y2security/clients/security_policy_proposal.rb
@@ -83,7 +83,6 @@ module Y2Security
         case action
         when "toggle-policy"
           toggle_policy(id.to_sym)
-          refresh_packages
         when "toggle-rule"
           toggle_rule(id)
         when "fix-rule"
@@ -190,16 +189,6 @@ module Y2Security
       def fix_rule(id)
         rule = find_rule(id)
         rule&.fix(target_config)
-      end
-
-      # Adds or removes the packages needed by the policy to or from the Packages Proposal
-      def refresh_packages
-        policies.each do |policy|
-          enabled = policies_manager.enabled_policy?(policy)
-          method = enabled ? "AddResolvables" : "RemoveResolvables"
-
-          Yast::PackagesProposal.public_send(method, "security", :package, policy.packages)
-        end
       end
 
       # Parses a link

--- a/src/lib/y2security/security_policies/disa_stig_policy.rb
+++ b/src/lib/y2security/security_policies/disa_stig_policy.rb
@@ -38,7 +38,7 @@ module Y2Security
         # TRANSLATORS: This is a security policy name.
         #   "Defense Information Systems Agency" is from the USA, https://disa.mil/
         #   STIG = Security Technical Implementation Guides
-        super(:disa_stig, _("Defense Information Systems Agency STIG"), ["scap-security-guide"])
+        super(:disa_stig, _("Defense Information Systems Agency STIG"))
       end
 
       def rules

--- a/src/lib/y2security/security_policies/manager.rb
+++ b/src/lib/y2security/security_policies/manager.rb
@@ -167,6 +167,10 @@ module Y2Security
       end
 
       # Return the list of enabled services
+      #
+      # FIXME: avoid a cyclic dependency with yast2-installation
+      #
+      # @return [Array<String>] List of enabled services
       def enabled_services
         require "installation/services" unless defined?(::Installation::Services)
         ::Installation::Services.enabled

--- a/src/lib/y2security/security_policies/manager.rb
+++ b/src/lib/y2security/security_policies/manager.rb
@@ -21,6 +21,8 @@ require "yast"
 require "singleton"
 require "y2security/security_policies/disa_stig_policy"
 
+Yast.import "PackagesProposal"
+
 module Y2Security
   module SecurityPolicies
     # Class to manage security policies
@@ -74,13 +76,17 @@ module Y2Security
         return unless policies.include?(policy)
 
         @enabled_policies.push(policy).uniq!
+        enable_service
       end
 
       # Disables the given policy
       #
       # @param policy [Policy]
       def disable_policy(policy)
+        return unless policies.include?(policy)
+
         @enabled_policies.delete(policy)
+        disable_service if @enabled_policies.empty?
       end
 
       # Whether the given policy is enabled
@@ -139,6 +145,35 @@ module Y2Security
         return [] unless key
 
         ENV[key].split(",")
+      end
+
+      SERVICE_NAME = "ssg-apply".freeze
+      private_constant :SERVICE_NAME
+
+      # Adds the package and enables the service to remedy the system after the installation
+      def enable_service
+        return if enabled_services.include?(SERVICE_NAME)
+
+        enabled_services << SERVICE_NAME
+        Yast::PackagesProposal.AddResolvables("security", :package, [SERVICE_NAME])
+      end
+
+      # Disables the service and removes the package to remedy the system after the installation
+      def disable_service
+        return unless enabled_services.include?(SERVICE_NAME)
+
+        enabled_services.delete(SERVICE_NAME)
+        Yast::PackagesProposal.RemoveResolvables("security", :package, [SERVICE_NAME])
+      end
+
+      # Return the list of enabled services
+      def enabled_services
+        require "installation/services" unless defined?(::Installation::Services)
+        ::Installation::Services.enabled
+      rescue LoadError
+        log.warn("Could not load the list of enabled services. " \
+          "Make sure yast2-installation is installed.")
+        []
       end
     end
   end

--- a/src/lib/y2security/security_policies/policy.rb
+++ b/src/lib/y2security/security_policies/policy.rb
@@ -35,18 +35,11 @@ module Y2Security
       # @return [String]
       attr_reader :name
 
-      # Packages to install for the policy
-      #
-      # @return [Array<String>]
-      attr_reader :packages
-
       # @param id [Symbol]
       # @param name [String]
-      # @param packages [Array<String>]
-      def initialize(id, name, packages = [])
+      def initialize(id, name)
         @id = id
         @name = name
-        @packages = packages
       end
 
       # @param config [TargetConfig] Configuration to check

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -81,4 +81,16 @@ module Installation
 
     def enable_firewall!; end
   end
+
+  class Services
+    class << self
+      def enabled
+        @enabled ||= []
+      end
+
+      def reset
+        enabled.clear
+      end
+    end
+  end
 end

--- a/test/y2security/clients/security_policy_proposal_test.rb
+++ b/test/y2security/clients/security_policy_proposal_test.rb
@@ -26,7 +26,7 @@ require "y2storage/devicegraph"
 class DummyPolicy < Y2Security::SecurityPolicies::Policy
   def initialize
     textdomain "security"
-    super(:dummy, _("Dummy policy"), [])
+    super(:dummy, _("Dummy policy"))
   end
 
   def rules
@@ -69,12 +69,6 @@ describe Y2Security::Clients::SecurityPolicyProposal do
     context "when a policy is enabled" do
       before do
         policies_manager.enable_policy(policy)
-      end
-
-      xit "adds the packages needed by the policy to the packages proposal" do
-        expect(Yast::PackagesProposal).to receive(:AddResolvables)
-          .with("security", :package, disa_stig_policy.packages)
-        subject.make_proposal({})
       end
 
       it "includes a link to disable the policy" do
@@ -188,12 +182,6 @@ describe Y2Security::Clients::SecurityPolicyProposal do
     context "when the policy is not enabled" do
       before do
         policies_manager.disable_policy(policy)
-      end
-
-      xit "removes the packages needed by the policy from the packages proposal" do
-        expect(Yast::PackagesProposal).to receive(:RemoveResolvables)
-          .with("security", :package, disa_stig_policy.packages)
-        subject.make_proposal({})
       end
 
       it "includes a link to enable the policy" do


### PR DESCRIPTION
- https://trello.com/c/H2WYkfZf/3081-3-stig-trigger-check-on-first-boot-with-persisted-list-of-disabled-rules

* When a security policy is enabled, set the `ssg-apply` package and service for installation.
* When no security policies are enabled, remove the `ssg-apply` package and service.
