### PR TITLE
Write `ssg-apply` configuration file

### DIFF
--- a/doc/security_policies.md
+++ b/doc/security_policies.md
@@ -52,8 +52,6 @@ the following rules should be checked:
 * [SLES-15-010200](http://static.open-scap.org/ssg-guides/ssg-sle15-guide-stig.html#xccdf_org.ssgproject.content_group_uefi) A bootloader password (for grub2) is configured (UEFI) ([stigviewer](https://www.stigviewer.com/stig/suse_linux_enterprise_server_15/2021-11-30/finding/V-234820)).
 * [SLES-15-010190](http://static.open-scap.org/ssg-guides/ssg-sle15-guide-stig.html#xccdf_org.ssgproject.content_group_non-uefi) A bootloader password (for grub2) is configured (BIOS) ([stigviewer](https://www.stigviewer.com/stig/suse_linux_enterprise_server_15/2022-02-11/finding/V-234819)).
 
-*NOTE: rules SLES-15-030660 and SLES-15-010190 are not checked by YaST yet.*
-
 Apart from the rules above, YaST also checks these other rules at installation time:
 
 * [SLES-15-010220](http://static.open-scap.org/ssg-guides/ssg-sle15-guide-stig.html#xccdf_org.ssgproject.content_rule_service_firewalld_enabled) Firewalld is enabled ([stigviewer](https://www.stigviewer.com/stig/suse_linux_enterprise_server_15/2021-11-30/finding/V-234821)).

--- a/src/lib/cfa/ssg_apply.rb
+++ b/src/lib/cfa/ssg_apply.rb
@@ -89,6 +89,7 @@ module CFA
     #   new_rule = Rule.new("SLES-15-000000", "My dummy rule", :unknown)
     #   file.disabled_rules = rules + [new_rule]
     #
+    # @param value [Array<String>] List of disabled rules IDs
     def disabled_rules=(value)
       @disabled_rules = nil
       generic_set("disabled-rules", value.join(","))

--- a/src/lib/cfa/ssg_apply.rb
+++ b/src/lib/cfa/ssg_apply.rb
@@ -1,0 +1,64 @@
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "cfa/base_model"
+require "yast2/target_file"
+
+module CFA
+  # CFA-based class to handle the ssg-apply configuration file
+  #
+  # @example Writing the base configuration
+  #   file = SsgApply.new
+  #   file.profile = "disa_stig"
+  #   file.disabled_rules = ["SLES-15-010190"]
+  #   file.save
+  #
+  # @example Loading the configuration from a given file path
+  #   file = SsgApply.new(file_path: "/etc/ssg-apply/default.conf")
+  #   file.load
+  #   file.profile #=> "stig"
+  #   file.disabled_rules #=> []
+  class SsgApply < BaseModel
+    extend Yast::Logger
+    include Yast::Logger
+
+    PATH = "/etc/ssg-apply/override.conf".freeze
+    LENS = "simplevars.lns".freeze
+    private_constant :LENS
+
+    attributes(
+      profile: "profile", disabled_rules: "disabled-rules"
+    )
+
+    def initialize(file_handler: Yast::TargetFile, file_path: PATH)
+      super(AugeasParser.new(LENS), file_path, file_handler: file_handler)
+    end
+
+    def disabled_rules
+      @disabled_rules ||= generic_get("disabled-rules")
+        .to_s.split(",").freeze
+    end
+
+    def disabled_rules=(value)
+      @disabled_rules = nil
+      generic_set("disabled-rules", value.join(","))
+    end
+  end
+end

--- a/src/lib/y2security/clients/security_policy_proposal.rb
+++ b/src/lib/y2security/clients/security_policy_proposal.rb
@@ -83,7 +83,6 @@ module Y2Security
         case action
         when "toggle-policy"
           toggle_policy(id.to_sym)
-          refresh_packages
         when "toggle-rule"
           toggle_rule(id)
         when "fix-rule"
@@ -205,16 +204,6 @@ module Y2Security
       def fix_rule(id)
         rule = find_rule(id)
         rule&.fix(target_config)
-      end
-
-      # Adds or removes the packages needed by the policy to or from the Packages Proposal
-      def refresh_packages
-        policies.each do |policy|
-          enabled = policies_manager.enabled_policy?(policy)
-          method = enabled ? "AddResolvables" : "RemoveResolvables"
-
-          Yast::PackagesProposal.public_send(method, "security", :package, policy.packages)
-        end
       end
 
       # Parses a link

--- a/src/lib/y2security/clients/security_policy_proposal.rb
+++ b/src/lib/y2security/clients/security_policy_proposal.rb
@@ -454,7 +454,7 @@ module Y2Security
         # @param rules [Array<Y2Security::SecurityPolicies::Rule>] Rules to display
         # @return [String]
         def rules_list(rules)
-          items = rules.map { |r| RulePresenter.new(r, links_builder).to_html }
+          items = rules.sort_by(&:id).map { |r| RulePresenter.new(r, links_builder).to_html }
 
           Yast::HTML.List(items)
         end

--- a/src/lib/y2security/clients/security_policy_proposal.rb
+++ b/src/lib/y2security/clients/security_policy_proposal.rb
@@ -21,6 +21,7 @@ require "yast"
 require "installation/proposal_client"
 require "y2security/security_policies/manager"
 require "y2security/security_policies/target_config"
+require "y2security/security_policies/unknown_rule"
 
 Yast.import "Wizard"
 
@@ -419,11 +420,15 @@ module Y2Security
 
         # HTML section describing the disabled rules
         #
+        # @note Unknown rules are filtered out.
+        #
         # @see Yast::HTML
         #
         # @return [String]
         def disabled_rules_section
-          disabled_rules = policy.rules.reject(&:enabled?)
+          disabled_rules = policy.rules.reject do |rule|
+            rule.enabled? || rule.is_a?(SecurityPolicies::UnknownRule)
+          end
 
           return nil if disabled_rules.none?
 

--- a/src/lib/y2security/security_policies/disa_stig_policy.rb
+++ b/src/lib/y2security/security_policies/disa_stig_policy.rb
@@ -41,7 +41,7 @@ module Y2Security
         # TRANSLATORS: This is a security policy name.
         #   "Defense Information Systems Agency" is from the USA, https://disa.mil/
         #   STIG = Security Technical Implementation Guides
-        super(:disa_stig, _("Defense Information Systems Agency STIG"), ["scap-security-guide"])
+        super(:disa_stig, _("Defense Information Systems Agency STIG"))
       end
 
       def rules

--- a/src/lib/y2security/security_policies/manager.rb
+++ b/src/lib/y2security/security_policies/manager.rb
@@ -167,6 +167,10 @@ module Y2Security
       end
 
       # Return the list of enabled services
+      #
+      # FIXME: avoid a cyclic dependency with yast2-installation
+      #
+      # @return [Array<String>] List of enabled services
       def enabled_services
         require "installation/services" unless defined?(::Installation::Services)
         ::Installation::Services.enabled

--- a/src/lib/y2security/security_policies/manager.rb
+++ b/src/lib/y2security/security_policies/manager.rb
@@ -21,6 +21,8 @@ require "yast"
 require "singleton"
 require "y2security/security_policies/disa_stig_policy"
 
+Yast.import "PackagesProposal"
+
 module Y2Security
   module SecurityPolicies
     # Class to manage security policies
@@ -74,13 +76,17 @@ module Y2Security
         return unless policies.include?(policy)
 
         @enabled_policies.push(policy).uniq!
+        enable_service
       end
 
       # Disables the given policy
       #
       # @param policy [Policy]
       def disable_policy(policy)
+        return unless policies.include?(policy)
+
         @enabled_policies.delete(policy)
+        disable_service if @enabled_policies.empty?
       end
 
       # Whether the given policy is enabled
@@ -139,6 +145,35 @@ module Y2Security
         return [] unless key
 
         ENV[key].split(",")
+      end
+
+      SERVICE_NAME = "ssg-apply".freeze
+      private_constant :SERVICE_NAME
+
+      # Adds the package and enables the service to remedy the system after the installation
+      def enable_service
+        return if enabled_services.include?(SERVICE_NAME)
+
+        enabled_services << SERVICE_NAME
+        Yast::PackagesProposal.AddResolvables("security", :package, [SERVICE_NAME])
+      end
+
+      # Disables the service and removes the package to remedy the system after the installation
+      def disable_service
+        return unless enabled_services.include?(SERVICE_NAME)
+
+        enabled_services.delete(SERVICE_NAME)
+        Yast::PackagesProposal.RemoveResolvables("security", :package, [SERVICE_NAME])
+      end
+
+      # Return the list of enabled services
+      def enabled_services
+        require "installation/services" unless defined?(::Installation::Services)
+        ::Installation::Services.enabled
+      rescue LoadError
+        log.warn("Could not load the list of enabled services. " \
+          "Make sure yast2-installation is installed.")
+        []
       end
     end
   end

--- a/src/lib/y2security/security_policies/manager.rb
+++ b/src/lib/y2security/security_policies/manager.rb
@@ -126,8 +126,7 @@ module Y2Security
         id = policy&.id || ""
         rules = policy&.rules || []
 
-        file = CFA::SsgApply.new
-        file.load
+        file = CFA::SsgApply.load
         file.profile = id.to_s
         file.disabled_rules = rules.reject(&:enabled?).map(&:id)
         file.save

--- a/src/lib/y2security/security_policies/policy.rb
+++ b/src/lib/y2security/security_policies/policy.rb
@@ -35,18 +35,11 @@ module Y2Security
       # @return [String]
       attr_reader :name
 
-      # Packages to install for the policy
-      #
-      # @return [Array<String>]
-      attr_reader :packages
-
       # @param id [Symbol]
       # @param name [String]
-      # @param packages [Array<String>]
-      def initialize(id, name, packages = [])
+      def initialize(id, name)
         @id = id
         @name = name
-        @packages = packages
       end
 
       # @param config [TargetConfig] Configuration to check

--- a/src/lib/y2security/security_policies/unknown_rule.rb
+++ b/src/lib/y2security/security_policies/unknown_rule.rb
@@ -1,0 +1,51 @@
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require "yast"
+require "y2security/security_policies/rule"
+
+module Y2Security
+  module SecurityPolicies
+    # Represents an unknown rule
+    #
+    # Unknown rules usually come from an AutoYaST profile. The profile allows disabling rules, but
+    # some of the given rules could be unknown by YaST. Note that YaST is aware of only an small
+    # subset of rules that should be fixed at installation time. For the rest of rules, an unknown
+    # rule is added to the policy when importing the profile.
+    class UnknownRule < Rule
+      include Yast::I18n
+
+      # @param id [String] Rule ID (e.g., "SLES-15-010190")
+      def initialize(id)
+        textdomain "security"
+        super(id, _("Unknown rule"), :unknown)
+      end
+
+      # Unknown rules are always considered as passing.
+      def pass?(_target_config)
+        true
+      end
+
+      # Unknown rules cannot be fixed
+      def fixable?
+        false
+      end
+    end
+  end
+end

--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -34,6 +34,7 @@ require "security/ctrl_alt_del_config"
 require "security/display_manager"
 require "y2security/autoinst/lsm_config_reader"
 require "y2security/security_policies"
+require "y2security/security_policies/unknown_rule"
 require "y2security/autoinst_profile"
 
 module Yast
@@ -959,6 +960,10 @@ module Yast
         manager.enable_policy(policy)
         section.disabled_rules.each do |rule_id|
           rule = policy.rules.find { |r| r.id == rule_id }
+          if rule.nil?
+            rule = Y2Security::SecurityPolicies::UnknownRule.new(rule_id)
+            policy.rules << rule
+          end
           rule&.disable
         end
       end

--- a/test/cfa/ssg_apply_test.rb
+++ b/test/cfa/ssg_apply_test.rb
@@ -1,0 +1,76 @@
+#!/usr/bin/env rspec
+
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../test_helper"
+require "cfa/ssg_apply"
+
+describe CFA::SsgApply do
+  subject(:file) do
+    described_class.new(file_path: file_path)
+  end
+
+  let(:file_path) { File.join(DATA_PATH, "system/etc/ssg-apply/default.conf") }
+
+  describe ".load" do
+    context "when the file exists" do
+      it "reads the file content" do
+        file = described_class.load(file_path: file_path)
+        expect(file).to be_a(described_class)
+        expect(file.profile).to eq("stig")
+      end
+    end
+
+    context "when the file does not exist" do
+      let(:file_path) do
+        File.join(DATA_PATH, "system/etc/ssg-apply/another.conf")
+      end
+
+      it "returns an empty file" do
+        file = described_class.load(file_path: file_path)
+        expect(file).to be_empty
+      end
+    end
+  end
+
+  describe "#profile" do
+    it "returns the profile value" do
+      file.load
+      expect(file.profile).to eq("stig")
+    end
+  end
+
+  describe "#disabled_rules" do
+    context "when a 'disabled_rules' list is specified" do
+      let(:file_path) { File.join(DATA_PATH, "system/etc/ssg-apply/override.conf") }
+
+      it "returns an array containing the disabled rules" do
+        file.load
+        expect(file.disabled_rules).to eq(["SLES-15-040200", "SLES-15-010200"])
+      end
+    end
+
+    context "when no 'disabled_rules' list is specified" do
+      it "returns an empty array" do
+        expect(file.disabled_rules).to eq([])
+      end
+    end
+  end
+end

--- a/test/cfa/ssg_apply_test.rb
+++ b/test/cfa/ssg_apply_test.rb
@@ -73,4 +73,12 @@ describe CFA::SsgApply do
       end
     end
   end
+
+  describe "#disabled_rules=" do
+    it "sets the 'disabled-rules' key to a comma separated list" do
+      expect(file).to receive(:generic_set)
+        .with("disabled-rules", "SLES-15-040200,SLES-15-010200")
+      file.disabled_rules = ["SLES-15-040200", "SLES-15-010200"]
+    end
+  end
 end

--- a/test/data/system/etc/ssg-apply/default.conf
+++ b/test/data/system/etc/ssg-apply/default.conf
@@ -1,0 +1,24 @@
+#
+# This is the configuration file for the ssg-apply executable.
+#
+
+#
+# content-file - scap-security-guide content to be used for eval/remediation
+# 
+content-file=/usr/share/xml/scap/ssg/content/ssg-sle15-ds.xml
+
+#
+# profile - profile as specified in content-file
+#
+profile=stig
+
+#
+# remediation setting - Take care before changing this setting to "yes",
+# as enabling remediation will likely make changes to the system.
+#
+remediate=no
+
+#
+# tailoring-file - tailoring file to disable specific rules
+#
+tailoring-file=none

--- a/test/data/system/etc/ssg-apply/override.conf
+++ b/test/data/system/etc/ssg-apply/override.conf
@@ -1,0 +1,1 @@
+disabled-rules=SLES-15-040200,SLES-15-010200

--- a/test/security_test.rb
+++ b/test/security_test.rb
@@ -801,7 +801,7 @@ module Yast
 
         let(:profile) do
           [
-            { "name" => "disa_stig", "disabled_rules" => ["SLES-15-030660"] }
+            { "name" => "disa_stig", "disabled_rules" => ["SLES-15-030660", "SLES-15-00001"] }
           ]
         end
 
@@ -818,6 +818,13 @@ module Yast
         it "disables the unwanted rules" do
           subject.Import("SECURITY_POLICIES" => profile)
           rule = policy.rules.find { |r| r.id == "SLES-15-030660" }
+          expect(rule).to_not be_enabled
+        end
+
+        it "adds the unknown rules as disabled" do
+          subject.Import("SECURITY_POLICIES" => profile)
+          rule = policy.rules.find { |r| r.id == "SLES-15-00001" }
+          expect(rule).to be_a(Y2Security::SecurityPolicies::UnknownRule)
           expect(rule).to_not be_enabled
         end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -81,4 +81,16 @@ module Installation
 
     def enable_firewall!; end
   end
+
+  class Services
+    class << self
+      def enabled
+        @enabled ||= []
+      end
+
+      def reset
+        enabled.clear
+      end
+    end
+  end
 end

--- a/test/y2security/clients/security_policy_proposal_test.rb
+++ b/test/y2security/clients/security_policy_proposal_test.rb
@@ -26,7 +26,7 @@ require "y2storage/devicegraph"
 class DummyPolicy < Y2Security::SecurityPolicies::Policy
   def initialize
     textdomain "security"
-    super(:dummy, _("Dummy policy"), [])
+    super(:dummy, _("Dummy policy"))
   end
 
   def rules
@@ -69,12 +69,6 @@ describe Y2Security::Clients::SecurityPolicyProposal do
     context "when a policy is enabled" do
       before do
         policies_manager.enable_policy(policy)
-      end
-
-      xit "adds the packages needed by the policy to the packages proposal" do
-        expect(Yast::PackagesProposal).to receive(:AddResolvables)
-          .with("security", :package, disa_stig_policy.packages)
-        subject.make_proposal({})
       end
 
       it "includes a link to disable the policy" do
@@ -208,12 +202,6 @@ describe Y2Security::Clients::SecurityPolicyProposal do
     context "when the policy is not enabled" do
       before do
         policies_manager.disable_policy(policy)
-      end
-
-      xit "removes the packages needed by the policy from the packages proposal" do
-        expect(Yast::PackagesProposal).to receive(:RemoveResolvables)
-          .with("security", :package, disa_stig_policy.packages)
-        subject.make_proposal({})
       end
 
       it "includes a link to enable the policy" do

--- a/test/y2security/security_policies/manager_test.rb
+++ b/test/y2security/security_policies/manager_test.rb
@@ -246,8 +246,7 @@ describe Y2Security::SecurityPolicies::Manager do
 
   describe "#write_config" do
     before do
-      allow(CFA::SsgApply).to receive(:new).and_return(ssg_apply_file)
-      allow(ssg_apply_file).to receive(:load)
+      allow(CFA::SsgApply).to receive(:load).and_return(ssg_apply_file)
       allow(ssg_apply_file).to receive(:save)
 
       allow(disa_stig_policy).to receive(:rules).and_return(rules)

--- a/test/y2security/security_policies/manager_test.rb
+++ b/test/y2security/security_policies/manager_test.rb
@@ -20,6 +20,7 @@
 require_relative "../../test_helper"
 require "y2security/security_policies/manager"
 require "y2security/security_policies/disa_stig_policy"
+require "y2security/security_policies/unknown_rule"
 
 describe Y2Security::SecurityPolicies::Manager do
   before do
@@ -239,6 +240,54 @@ describe Y2Security::SecurityPolicies::Manager do
           expect(subject.failing_rules(target_config, include_disabled: true))
             .to eq(disa_stig_policy => [rule])
         end
+      end
+    end
+  end
+
+  describe "#write_config" do
+    before do
+      allow(CFA::SsgApply).to receive(:new).and_return(ssg_apply_file)
+      allow(ssg_apply_file).to receive(:load)
+      allow(ssg_apply_file).to receive(:save)
+
+      allow(disa_stig_policy).to receive(:rules).and_return(rules)
+    end
+
+    let(:ssg_apply_file) { CFA::SsgApply.new }
+
+    let(:rules) { [rule1, rule2, rule3] }
+
+    let(:rule1) { Y2Security::SecurityPolicies::UnknownRule.new("rule1").tap(&:disable) }
+    let(:rule2) { Y2Security::SecurityPolicies::UnknownRule.new("rule2").tap(&:enable) }
+    let(:rule3) { Y2Security::SecurityPolicies::UnknownRule.new("rule3").tap(&:disable) }
+
+    context "when a security policy is enabled" do
+      before do
+        subject.enable_policy(disa_stig_policy)
+      end
+
+      it "writes the profile and disabled rules in the ssg-apply config" do
+        expect(ssg_apply_file).to receive(:save)
+
+        subject.write_config
+
+        expect(ssg_apply_file.profile).to eq("disa_stig")
+        expect(ssg_apply_file.disabled_rules).to contain_exactly("rule1", "rule3")
+      end
+    end
+
+    context "when no security policy is enabled" do
+      before do
+        subject.disable_policy(disa_stig_policy)
+      end
+
+      it "writes no policy and no disabled rules in the ssg-apply config" do
+        expect(ssg_apply_file).to receive(:save)
+
+        subject.write_config
+
+        expect(ssg_apply_file.profile).to eq("")
+        expect(ssg_apply_file.disabled_rules).to be_empty
       end
     end
   end

--- a/test/y2security/security_policies/unknown_rule_test.rb
+++ b/test/y2security/security_policies/unknown_rule_test.rb
@@ -1,0 +1,43 @@
+# Copyright (c) [2022] SUSE LLC
+#
+# All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of version 2 of the GNU General Public License as published
+# by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+# more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, contact SUSE LLC.
+#
+# To contact SUSE LLC about this file by physical or electronic mail, you may
+# find current contact information at www.suse.com.
+
+require_relative "../../test_helper"
+require "y2security/security_policies/unknown_rule"
+
+describe Y2Security::SecurityPolicies::UnknownRule do
+  subject { described_class.new("SLES-15-010530") }
+
+  describe "#id" do
+    it "returns the rule ID" do
+      expect(subject.id).to eq("SLES-15-010530")
+    end
+  end
+
+  describe "#pass?" do
+    it "returns true" do
+      expect(subject.pass?(nil)).to eq(true)
+    end
+  end
+
+  describe "#fixable?" do
+    it "returns false" do
+      expect(subject.fixable?).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
The `ssg-apply` tool read its configuration from the `default.conf` and `override.conf` files in the`/etc/ssg-apply` directory. The idea of this PR is to write the configuration in the latter of those files, including the policy to apply and the rules to ignore.

This PR also contains some fixes in the policies proposal. 