### PR TITLE
Config for ssg-apply script

### DIFF
--- a/src/lib/cfa/ssg_apply.rb
+++ b/src/lib/cfa/ssg_apply.rb
@@ -71,6 +71,14 @@ module CFA
       super(AugeasParser.new(LENS), file_path, file_handler: file_handler)
     end
 
+    # Removes empty values before saving, otherwise the lens complains
+    def save
+      matcher = CFA::Matcher.new { |_, v| v.strip.empty? }
+      empty_elements = data.select(matcher).map { |e| e[:key] }
+      empty_elements.each { |e| data.delete(e) }
+      super
+    end
+
     # Returns the list of disabled rules
     #
     # To add rules to the list, please use the #disabled_rules= method instead of

--- a/src/lib/cfa/ssg_apply.rb
+++ b/src/lib/cfa/ssg_apply.rb
@@ -27,7 +27,8 @@ module CFA
   # @example Writing the base configuration
   #   file = SsgApply.new
   #   file.profile = "disa_stig"
-  #   file.disabled_rules = ["SLES-15-010190"]
+  #   file.remediation = "/usr/share/scap-security-guide/bash/sle15-script-stig.sh"
+  #   file.disabled_rules = ["partition_for_home"]
   #   file.save
   #
   # @example Loading the configuration from a given file path
@@ -44,7 +45,7 @@ module CFA
     private_constant :LENS
 
     attributes(
-      profile: "profile", disabled_rules: "disabled-rules"
+      profile: "profile", remediation: "remediation", disabled_rules: "disabled-rules"
     )
 
     class << self

--- a/src/lib/y2security/autoinst_profile/security_policy_section.rb
+++ b/src/lib/y2security/autoinst_profile/security_policy_section.rb
@@ -28,7 +28,7 @@ module Y2Security
     #     <listitem>
     #       <name>disa_stig</name>
     #       <disabled_rules t="list">
-    #         <listitem>SLES-15-020400</listitem>
+    #         <listitem>encrypt_partitions</listitem>
     #       </disabled_rules>
     #     </listitem>
     #   </security_policies>
@@ -45,7 +45,7 @@ module Y2Security
       # @!attribute name
       #   @return [String] Policy name to apply
       # @!attribute disabled_rules
-      #   @return [Array<String>] Rules to ignore
+      #   @return [Array<String>] Name of the rules to ignore
 
       def initialize(parent = nil)
         super

--- a/src/lib/y2security/security_policies/bootloader_password_rule.rb
+++ b/src/lib/y2security/security_policies/bootloader_password_rule.rb
@@ -39,7 +39,7 @@ module Y2Security
         end
 
         # TRANSLATORS: security policy rule
-        description = _("Bootloader must be protected by password and menu editing must be " \
+        description = _("Boot loader must be protected by password and menu editing must be " \
           "restricted")
 
         super(name, id: id, description: description, scope: :bootloader)

--- a/src/lib/y2security/security_policies/bootloader_password_rule.rb
+++ b/src/lib/y2security/security_policies/bootloader_password_rule.rb
@@ -29,15 +29,20 @@ module Y2Security
 
         # DISA STIG defines a rule for UEFI (SLES-15-010200) and another rule for non-UEFI
         # (SLES-15-010190). The condition to check both rules in YaST is exactly the same, so let's
-        # simply adapt the rule ID according to the system type.
-        id = Y2Storage::Arch.new.efiboot? ? "SLES-15-010200" : "SLES-15-010190"
+        # simply adapt the rule name and ID according to the system type.
+        if Y2Storage::Arch.new.efiboot?
+          name = "grub2_uefi_password"
+          id = "SLES-15-010200"
+        else
+          name = "grub2_password"
+          id = "SLES-15-010190"
+        end
 
-        super(
-          id,
-          # TRANSLATORS: security policy rule
-          _("Bootloader must be protected by password and menu editing must be restricted"),
-          :bootloader
-        )
+        # TRANSLATORS: security policy rule
+        description = _("Bootloader must be protected by password and menu editing must be " \
+          "restricted")
+
+        super(name, id: id, description: description, scope: :bootloader)
       end
 
       # @see Rule#pass?

--- a/src/lib/y2security/security_policies/disa_stig_policy.rb
+++ b/src/lib/y2security/security_policies/disa_stig_policy.rb
@@ -41,16 +41,20 @@ module Y2Security
         # TRANSLATORS: This is a security policy name.
         #   "Defense Information Systems Agency" is from the USA, https://disa.mil/
         #   STIG = Security Technical Implementation Guides
-        super(:disa_stig, _("Defense Information Systems Agency STIG"))
+        name = _("Defense Information Systems Agency STIG")
+        remediation = "/usr/share/scap-security-guide/bash/sle15-script-stig.sh"
+
+        super(:disa_stig, name, remediation)
       end
 
       def rules
         @rules ||= [
-          MissingMountPointRule.new("SLES-15-040200", "/home"),
-          MissingMountPointRule.new("SLES-15-040210", "/var"),
-          SeparateFilesystemRule.new("SLES-15-030810", "/var/log/audit"),
-          FilesystemSizeRule.new("SLES-15-030660", "/var/log/audit",
-            min_size: Y2Storage::DiskSize.MiB(100)),
+          MissingMountPointRule.new("partition_for_home", "SLES-15-040200", "/home"),
+          MissingMountPointRule.new("partition_for_var", "SLES-15-040210", "/var"),
+          SeparateFilesystemRule.new("partition_for_var_log_audit",
+            "SLES-15-030810", "/var/log/audit"),
+          FilesystemSizeRule.new("auditd_audispd_configure_sufficiently_large_partition",
+            "SLES-15-030660", "/var/log/audit", min_size: Y2Storage::DiskSize.MiB(100)),
           MissingEncryptionRule.new,
           NoWirelessRule.new,
           FirewallEnabledRule.new,

--- a/src/lib/y2security/security_policies/filesystem_size_rule.rb
+++ b/src/lib/y2security/security_policies/filesystem_size_rule.rb
@@ -34,20 +34,21 @@ module Y2Security
       # @return [Y2Storage::DiskSize]
       attr_reader :min_size
 
+      # @param name [String] Rule name
       # @param id [String] Rule ID
       # @param mount_path [String] Mount path for the file system to check
       # @param min_size [Y2Storage::DiskSize] Minimum size the file system should have
-      def initialize(id, mount_path, min_size: nil)
+      def initialize(name, id, mount_path, min_size: nil)
         textdomain "security"
 
         @mount_path = mount_path
         @min_size = min_size || Y2Storage::DiskSize.new(0)
-        super(
-          id,
+        description = format(
           # TRANSLATORS: security policy rule, %s is a placeholder.
-          format(_("The minimum size for the file system %s must be %s"), mount_path, min_size),
-          :storage
+          _("The minimum size for the file system %s must be %s"), mount_path, min_size
         )
+
+        super(name, id: id, description: description, scope: :storage)
       end
 
       # @see Rule#pass?

--- a/src/lib/y2security/security_policies/firewall_enabled_rule.rb
+++ b/src/lib/y2security/security_policies/firewall_enabled_rule.rb
@@ -22,18 +22,15 @@ require "y2security/security_policies/rule"
 module Y2Security
   module SecurityPolicies
     # Rule to verify that the firewall is enabled (SLES-15-010220).
-    #
-    # @example Fix the current configuration if the rule does not pass
-    #   config = TargetConfig.new
-    #   rule = FirewallEnabledRule.new
-    #   rule.fix(config) unless rule.pass?(config)
-    #   config.security.enable_firewall #=> true
     class FirewallEnabledRule < Rule
       def initialize
         textdomain "security"
 
         # TRANSLATORS: security policy rule
-        super("SLES-15-010220", _("Firewall must be enabled"), :security)
+        description = _("Firewall must be enabled")
+
+        super("service_firewalld_enabled",
+          id: "SLES-15-010220", description: description, scope: :security)
       end
 
       # @see Rule#pass?

--- a/src/lib/y2security/security_policies/manager.rb
+++ b/src/lib/y2security/security_policies/manager.rb
@@ -125,12 +125,12 @@ module Y2Security
         # Only one policy is expected to be enabled
         policy = policies.find { |p| enabled_policy?(p) }
 
-        id = policy&.id || ""
-        rules = policy&.rules || []
+        return unless policy
 
         file = CFA::SsgApply.load
-        file.profile = id.to_s
-        file.disabled_rules = rules.reject(&:enabled?).map(&:id)
+        file.profile = policy.id.to_s
+        file.remediation = policy.remediation
+        file.disabled_rules = policy.rules.reject(&:enabled?).map(&:name)
         file.save
       end
 

--- a/src/lib/y2security/security_policies/missing_encryption_rule.rb
+++ b/src/lib/y2security/security_policies/missing_encryption_rule.rb
@@ -27,7 +27,10 @@ module Y2Security
       def initialize
         textdomain "security"
 
-        super("SLES-15-010330", _("All file systems must be encrypted"), :storage)
+        # TRANSLATORS: Security policy rule
+        description = _("All file systems must be encrypted")
+
+        super("encrypt_partitions", id: "SLES-15-010330", description: description, scope: :storage)
       end
 
       # @see Rule#pass?

--- a/src/lib/y2security/security_policies/missing_mount_point_rule.rb
+++ b/src/lib/y2security/security_policies/missing_mount_point_rule.rb
@@ -23,23 +23,21 @@ require "y2storage"
 module Y2Security
   module SecurityPolicies
     # Rule to check whether there is a separate mount point for a given path
-    #
-    # @example Check for a separate mount point for /home
-    #   config = TargetConfig.new
-    #   rule = MissingMountPointRule.new("SLES-15-040200", "/home")
-    #   rule.pass?(config)
     class MissingMountPointRule < Rule
       # @return [String] Mount point to check
       attr_reader :mount_point
 
+      # @param name [String] Rule name
       # @param id [String] Rule ID
       # @param mount_point [String] Mount point to check
-      def initialize(id, mount_point)
+      def initialize(name, id, mount_point)
         textdomain "security"
 
         @mount_point = mount_point
         # TRANSLATORS: security policy rule
-        super(id, format(_("There must be a separate mount point for %s"), mount_point), :storage)
+        description = format(_("There must be a separate mount point for %s"), mount_point)
+
+        super(name, id: id, description: description, scope: :storage)
       end
 
       # @see Rule#pass?

--- a/src/lib/y2security/security_policies/no_wireless_rule.rb
+++ b/src/lib/y2security/security_policies/no_wireless_rule.rb
@@ -24,19 +24,15 @@ require "y2network/startmode"
 module Y2Security
   module SecurityPolicies
     # Rule to deactivate wireless network interfaces (SLES-15-010380).
-    #
-    # @example Fix the current configuration if the rule does not pass
-    #   config = TargetConfig.new
-    #   rule = NoWirelessRule.new
-    #   rule.fix(config) unless rule.pass?(config)
-    #   wlan0 = config.network.connections.by_name("wlan0")
-    #   wlan0.startmode.to_s #=> "off"
     class NoWirelessRule < Rule
       def initialize
         textdomain "security"
 
-        # TRANSLATORS: security policy rule
-        super("SLES-15-010380", _("Wireless network interfaces must be deactivated"), :network)
+        # TRANSLATORS: Security policy rule
+        description = _("Wireless network interfaces must be deactivated")
+
+        super("wireless_disable_interfaces",
+          id: "SLES-15-010380", description: description, scope: :network)
       end
 
       # @see Rule#pass?

--- a/src/lib/y2security/security_policies/policy.rb
+++ b/src/lib/y2security/security_policies/policy.rb
@@ -35,11 +35,18 @@ module Y2Security
       # @return [String]
       attr_reader :name
 
+      # Path to the file provided by scap_security_guide to apply remediation for the policy
+      #
+      # @return [String]
+      attr_reader :remediation
+
       # @param id [Symbol]
       # @param name [String]
-      def initialize(id, name)
+      # @param remediation [String]
+      def initialize(id, name, remediation)
         @id = id
         @name = name
+        @remediation = remediation
       end
 
       # @param config [TargetConfig] Configuration to check

--- a/src/lib/y2security/security_policies/rule.rb
+++ b/src/lib/y2security/security_policies/rule.rb
@@ -28,6 +28,9 @@ module Y2Security
     class Rule
       include Yast::I18n
 
+      # @return [String] Rule name
+      attr_reader :name
+
       # @return [String] Rule ID
       attr_reader :id
 
@@ -37,10 +40,12 @@ module Y2Security
       # @return [Symbol] Scope to apply the rule to
       attr_reader :scope
 
+      # @param name [String] Rule name (e.g., "partition_for_home")
       # @param id [String] Rule ID (e.g., "SLES-15-010190")
       # @param description [String] Rule description
       # @param scope [Symbol] Scope
-      def initialize(id, description, scope)
+      def initialize(name, id: nil, description: nil, scope: nil)
+        @name = name
         @id = id
         @description = description
         @scope = scope

--- a/src/lib/y2security/security_policies/separate_filesystem_rule.rb
+++ b/src/lib/y2security/security_policies/separate_filesystem_rule.rb
@@ -28,14 +28,17 @@ module Y2Security
       # @return [String]
       attr_reader :mount_path
 
+      # @param name [String] Rule name
       # @param id [String] Rule ID
       # @param mount_path [String] Mount path for the file system to check
-      def initialize(id, mount_path)
+      def initialize(name, id, mount_path)
         textdomain "security"
 
         @mount_path = mount_path
         # TRANSLATORS: security policy rule, %s is a placeholder.
-        super(id, format(_("There must be a separate file system for %s"), mount_path), :storage)
+        description = format(_("There must be a separate file system for %s"), mount_path)
+
+        super(name, id: id, description: description, scope: :storage)
       end
 
       # @see Rule#pass?

--- a/src/lib/y2security/security_policies/unknown_rule.rb
+++ b/src/lib/y2security/security_policies/unknown_rule.rb
@@ -31,10 +31,11 @@ module Y2Security
     class UnknownRule < Rule
       include Yast::I18n
 
-      # @param id [String] Rule ID (e.g., "SLES-15-010190")
-      def initialize(id)
+      # @param name [String] Rule name
+      def initialize(name)
         textdomain "security"
-        super(id, _("Unknown rule"), :unknown)
+
+        super(name, description: _("Unknown rule"), scope: :unknown)
       end
 
       # Unknown rules are always considered as passing.

--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -958,10 +958,10 @@ module Yast
         end
 
         manager.enable_policy(policy)
-        section.disabled_rules.each do |rule_id|
-          rule = policy.rules.find { |r| r.id == rule_id }
+        section.disabled_rules.each do |rule_name|
+          rule = policy.rules.find { |r| r.name == rule_name }
           if rule.nil?
-            rule = Y2Security::SecurityPolicies::UnknownRule.new(rule_id)
+            rule = Y2Security::SecurityPolicies::UnknownRule.new(rule_name)
             policy.rules << rule
           end
           rule&.disable

--- a/test/cfa/ssg_apply_test.rb
+++ b/test/cfa/ssg_apply_test.rb
@@ -63,7 +63,7 @@ describe CFA::SsgApply do
 
       it "returns an array containing the disabled rules" do
         file.load
-        expect(file.disabled_rules).to eq(["SLES-15-040200", "SLES-15-010200"])
+        expect(file.disabled_rules).to eq(["partition_for_home", "encrypt_partitions"])
       end
     end
 
@@ -77,8 +77,8 @@ describe CFA::SsgApply do
   describe "#disabled_rules=" do
     it "sets the 'disabled-rules' key to a comma separated list" do
       expect(file).to receive(:generic_set)
-        .with("disabled-rules", "SLES-15-040200,SLES-15-010200")
-      file.disabled_rules = ["SLES-15-040200", "SLES-15-010200"]
+        .with("disabled-rules", "rule_name1,rule_name2")
+      file.disabled_rules = ["rule_name1", "rule_name2"]
     end
   end
 end

--- a/test/cfa/ssg_apply_test.rb
+++ b/test/cfa/ssg_apply_test.rb
@@ -24,10 +24,16 @@ require "cfa/ssg_apply"
 
 describe CFA::SsgApply do
   subject(:file) do
-    described_class.new(file_path: file_path)
+    described_class.new(file_handler: file_handler, file_path: file_path)
   end
 
+  let(:file_handler) { Yast::TargetFile }
+
   let(:file_path) { File.join(DATA_PATH, "system/etc/ssg-apply/default.conf") }
+
+  before do
+    allow(file_handler).to receive(:write)
+  end
 
   describe ".load" do
     context "when the file exists" do
@@ -46,6 +52,72 @@ describe CFA::SsgApply do
       it "returns an empty file" do
         file = described_class.load(file_path: file_path)
         expect(file).to be_empty
+      end
+    end
+  end
+
+  describe "#save" do
+    before do
+      file.profile = profile
+      file.remediation = remediation
+      file.disabled_rules = disabled_rules
+    end
+
+    let(:profile) { "disa_stig" }
+    let(:remediation) { "/path/to/file.sh" }
+    let(:disabled_rules) { ["rule1", "rule2"] }
+
+    it "writes the profile" do
+      expect(file_handler).to receive(:write).with(anything, /profile = disa_stig/)
+
+      file.save
+    end
+
+    it "writes the remediation" do
+      expect(file_handler).to receive(:write).with(anything, /remediation = \/path\/to\/file.sh/)
+
+      file.save
+    end
+
+    it "writes the disabled rules" do
+      expect(file_handler).to receive(:write).with(anything, /disabled-rules = rule1,rule2/)
+
+      file.save
+    end
+
+    context "when the profile is empty" do
+      let(:profile) { "" }
+
+      it "removes the profile key" do
+        expect(file_handler).to receive(:write) do |_, content|
+          expect(content).to_not include("profile")
+        end
+
+        file.save
+      end
+    end
+
+    context "when the remediation is empty" do
+      let(:remediation) { "" }
+
+      it "removes the remediation key" do
+        expect(file_handler).to receive(:write) do |_, content|
+          expect(content).to_not include("remediation")
+        end
+
+        file.save
+      end
+    end
+
+    context "when disabled rules is empty" do
+      let(:disabled_rules) { [] }
+
+      it "removes the disabled-rules key" do
+        expect(file_handler).to receive(:write) do |_, content|
+          expect(content).to_not include("disabled-rules")
+        end
+
+        file.save
       end
     end
   end

--- a/test/data/system/etc/ssg-apply/override.conf
+++ b/test/data/system/etc/ssg-apply/override.conf
@@ -1,1 +1,1 @@
-disabled-rules=SLES-15-040200,SLES-15-010200
+disabled-rules = partition_for_home,encrypt_partitions

--- a/test/security_test.rb
+++ b/test/security_test.rb
@@ -801,7 +801,13 @@ module Yast
 
         let(:profile) do
           [
-            { "name" => "disa_stig", "disabled_rules" => ["SLES-15-030660", "SLES-15-00001"] }
+            {
+              "name"           => "disa_stig",
+              "disabled_rules" => [
+                "partition_for_home",
+                "audit_rules_session_events_btmp"
+              ]
+            }
           ]
         end
 
@@ -817,13 +823,13 @@ module Yast
 
         it "disables the unwanted rules" do
           subject.Import("SECURITY_POLICIES" => profile)
-          rule = policy.rules.find { |r| r.id == "SLES-15-030660" }
+          rule = policy.rules.find { |r| r.name == "partition_for_home" }
           expect(rule).to_not be_enabled
         end
 
         it "adds the unknown rules as disabled" do
           subject.Import("SECURITY_POLICIES" => profile)
-          rule = policy.rules.find { |r| r.id == "SLES-15-00001" }
+          rule = policy.rules.find { |r| r.name == "audit_rules_session_events_btmp" }
           expect(rule).to be_a(Y2Security::SecurityPolicies::UnknownRule)
           expect(rule).to_not be_enabled
         end

--- a/test/y2security/autoinst_profile/security_policy_section_test.rb
+++ b/test/y2security/autoinst_profile/security_policy_section_test.rb
@@ -24,13 +24,13 @@ require "y2security/autoinst_profile/security_policy_section"
 describe Y2Security::AutoinstProfile::SecurityPolicySection do
   describe ".new_from_hashes" do
     let(:profile) do
-      { "name" => "disa_stig", "disabled_rules" => ["SLES-15-040200"] }
+      { "name" => "disa_stig", "disabled_rules" => ["partition_for_home"] }
     end
 
     it "sets the name and the list of ignored rules" do
       section = described_class.new_from_hashes(profile)
       expect(section.name).to eq("disa_stig")
-      expect(section.disabled_rules).to eq(["SLES-15-040200"])
+      expect(section.disabled_rules).to eq(["partition_for_home"])
     end
 
     context "an empty profile" do

--- a/test/y2security/autoinst_profile/security_section_test.rb
+++ b/test/y2security/autoinst_profile/security_section_test.rb
@@ -36,7 +36,7 @@ describe Y2Security::AutoinstProfile::SecuritySection do
       let(:profile) do
         {
           "security_policies" => [
-            { "name" => "disa_stig", "disabled_rules" => ["SLES-15-000000"] }
+            { "name" => "disa_stig", "disabled_rules" => ["partition_for_home"] }
           ]
         }
       end

--- a/test/y2security/clients/security_policy_proposal_test.rb
+++ b/test/y2security/clients/security_policy_proposal_test.rb
@@ -28,7 +28,7 @@ require "bootloader/main_dialog"
 class DummyPolicy < Y2Security::SecurityPolicies::Policy
   def initialize
     textdomain "security"
-    super(:dummy, _("Dummy policy"))
+    super(:dummy, _("Dummy policy"), "/remediation.sh")
   end
 
   def rules

--- a/test/y2security/clients/security_policy_proposal_test.rb
+++ b/test/y2security/clients/security_policy_proposal_test.rb
@@ -39,7 +39,7 @@ end
 class DummyRule < Y2Security::SecurityPolicies::Rule
   def initialize
     textdomain "security"
-    super("SLES-15-000000", _("Dummy rule"), :network)
+    super("dummy_rule", id: "SLES-15-000000", description: _("Dummy rule"), scope: :network)
   end
 end
 

--- a/test/y2security/security_policies/bootloader_password_rule_test.rb
+++ b/test/y2security/security_policies/bootloader_password_rule_test.rb
@@ -32,6 +32,24 @@ describe Y2Security::SecurityPolicies::BootloaderPasswordRule do
 
   let(:bootloader) { Bootloader::NoneBootloader.new }
 
+  describe "#name" do
+    context "in a UEFI system" do
+      let(:efiboot) { true }
+
+      it "returns grub2_uefi_password" do
+        expect(subject.name).to eq("grub2_uefi_password")
+      end
+    end
+
+    context "in a non-UEFI system" do
+      let(:efiboot) { false }
+
+      it "returns grub2_password" do
+        expect(subject.name).to eq("grub2_password")
+      end
+    end
+  end
+
   describe "#id" do
     context "in a UEFI system" do
       let(:efiboot) { true }

--- a/test/y2security/security_policies/disa_stig_policy_test.rb
+++ b/test/y2security/security_policies/disa_stig_policy_test.rb
@@ -29,7 +29,6 @@ describe Y2Security::SecurityPolicies::DisaStigPolicy do
   end
 
   describe "#rules" do
-
     before do
       allow(Y2Storage::Arch).to receive(:new).and_return(arch)
     end

--- a/test/y2security/security_policies/filesystem_size_rule_test.rb
+++ b/test/y2security/security_policies/filesystem_size_rule_test.rb
@@ -23,9 +23,17 @@ require "y2security/security_policies/target_config"
 require "y2storage"
 
 describe Y2Security::SecurityPolicies::FilesystemSizeRule do
-  subject { described_class.new("SLES-15-030660", "/var/log/audit", min_size: min_size) }
+  subject do
+    described_class.new("min_size", "SLES-15-030660", "/var/log/audit", min_size: min_size)
+  end
 
   let(:min_size) { Y2Storage::DiskSize.MiB(100) }
+
+  describe "#name" do
+    it "returns the rule name" do
+      expect(subject.name).to eq("min_size")
+    end
+  end
 
   describe "#id" do
     it "returns the rule ID" do

--- a/test/y2security/security_policies/firewall_enabled_rule_test.rb
+++ b/test/y2security/security_policies/firewall_enabled_rule_test.rb
@@ -33,6 +33,12 @@ describe Y2Security::SecurityPolicies::FirewallEnabledRule do
 
   let(:enabled) { true }
 
+  describe "#name" do
+    it "returns the rule name" do
+      expect(subject.name).to eq("service_firewalld_enabled")
+    end
+  end
+
   describe "#id" do
     it "returns the rule ID" do
       expect(subject.id).to eq("SLES-15-010220")

--- a/test/y2security/security_policies/manager_test.rb
+++ b/test/y2security/security_policies/manager_test.rb
@@ -265,12 +265,13 @@ describe Y2Security::SecurityPolicies::Manager do
         subject.enable_policy(disa_stig_policy)
       end
 
-      it "writes the profile and disabled rules in the ssg-apply config" do
+      it "writes the profile, remediation and disabled rules in the ssg-apply config" do
         expect(ssg_apply_file).to receive(:save)
 
         subject.write_config
 
         expect(ssg_apply_file.profile).to eq("disa_stig")
+        expect(ssg_apply_file.remediation).to eq(disa_stig_policy.remediation)
         expect(ssg_apply_file.disabled_rules).to contain_exactly("rule1", "rule3")
       end
     end
@@ -280,13 +281,10 @@ describe Y2Security::SecurityPolicies::Manager do
         subject.disable_policy(disa_stig_policy)
       end
 
-      it "writes no policy and no disabled rules in the ssg-apply config" do
-        expect(ssg_apply_file).to receive(:save)
+      it "does not write the ssg-apply config" do
+        expect(ssg_apply_file).to_not receive(:save)
 
         subject.write_config
-
-        expect(ssg_apply_file.profile).to eq("")
-        expect(ssg_apply_file.disabled_rules).to be_empty
       end
     end
   end

--- a/test/y2security/security_policies/manager_test.rb
+++ b/test/y2security/security_policies/manager_test.rb
@@ -98,7 +98,7 @@ describe Y2Security::SecurityPolicies::Manager do
     end
 
     context "if the given policy is unknown" do
-      let(:policy) { Y2Security::SecurityPolicies::Policy.new(:unknown, "Unknown") }
+      let(:policy) { Y2Security::SecurityPolicies::Policy.new(:unknown, "Unknown", "") }
 
       it "does not enable the policy" do
         subject.enable_policy(policy)

--- a/test/y2security/security_policies/missing_encryption_rule_test.rb
+++ b/test/y2security/security_policies/missing_encryption_rule_test.rb
@@ -22,6 +22,12 @@ require "y2security/security_policies/missing_encryption_rule"
 require "y2security/security_policies/target_config"
 
 describe Y2Security::SecurityPolicies::MissingEncryptionRule do
+  describe "#name" do
+    it "returns the rule name" do
+      expect(subject.name).to eq("encrypt_partitions")
+    end
+  end
+
   describe "#id" do
     it "returns the rule ID" do
       expect(subject.id).to eq("SLES-15-010330")

--- a/test/y2security/security_policies/missing_mount_point_rule_test.rb
+++ b/test/y2security/security_policies/missing_mount_point_rule_test.rb
@@ -22,7 +22,13 @@ require "y2security/security_policies/missing_mount_point_rule"
 require "y2security/security_policies/target_config"
 
 describe Y2Security::SecurityPolicies::MissingMountPointRule do
-  subject { described_class.new("SLES-15-040200", "/home") }
+  subject { described_class.new("partition_for_home", "SLES-15-040200", "/home") }
+
+  describe "#name" do
+    it "returns the rule name" do
+      expect(subject.name).to eq("partition_for_home")
+    end
+  end
 
   describe "#id" do
     it "returns the rule ID" do

--- a/test/y2security/security_policies/policy_examples.rb
+++ b/test/y2security/security_policies/policy_examples.rb
@@ -22,8 +22,8 @@ require "y2security/security_policies/policy"
 
 shared_examples "Y2Security::SecurityPolicies::Policy" do
   class TestRule < Y2Security::SecurityPolicies::Rule
-    def initialize(id, scope)
-      super(id, "Test rule #{id}", scope)
+    def initialize(name, scope)
+      super(name, description: "Test rule #{name}", scope: scope)
     end
   end
 

--- a/test/y2security/security_policies/separate_filesystem_rule_test.rb
+++ b/test/y2security/security_policies/separate_filesystem_rule_test.rb
@@ -22,7 +22,13 @@ require "y2security/security_policies/separate_filesystem_rule"
 require "y2security/security_policies/target_config"
 
 describe Y2Security::SecurityPolicies::SeparateFilesystemRule do
-  subject { described_class.new("SLES-15-030810", "/var/log/audit") }
+  subject { described_class.new("partition_for_var_log_audit", "SLES-15-030810", "/var/log/audit") }
+
+  describe "#name" do
+    it "returns the rule name" do
+      expect(subject.name).to eq("partition_for_var_log_audit")
+    end
+  end
 
   describe "#id" do
     it "returns the rule ID" do

--- a/test/y2security/security_policies/unknown_rule_test.rb
+++ b/test/y2security/security_policies/unknown_rule_test.rb
@@ -21,11 +21,17 @@ require_relative "../../test_helper"
 require "y2security/security_policies/unknown_rule"
 
 describe Y2Security::SecurityPolicies::UnknownRule do
-  subject { described_class.new("SLES-15-010530") }
+  subject { described_class.new("package_aide_installed") }
+
+  describe "#name" do
+    it "returns the rule name" do
+      expect(subject.name).to eq("package_aide_installed")
+    end
+  end
 
   describe "#id" do
-    it "returns the rule ID" do
-      expect(subject.id).to eq("SLES-15-010530")
+    it "returns nil" do
+      expect(subject.id).to be_nil
     end
   end
 


### PR DESCRIPTION
## Problem

YaST writes the configuration for the remediation script provided [*ssg-apply*]( https://drivers.suse.com/suse/SCAP/SUSE_SSG_Apply-1.0/sle-15-sp3-x86_64/install-readme.html) to the */etc/ssg-apply/override.conf* file, see  https://github.com/yast/yast-security/pull/137. YaST writes it in order to indicate to other tools what rules should be ignored. Now on *ssg-apply* will provide a new script for "disabling" rules (`mask-rule.sh`), and the configuration expected by such a script is slightly different to the config writen by YaST. 

Right now, YaST writes:

~~~
profile = disa_stig
disabled-rules = SLES-15-34512,SLES-15-45001
~~~

But the `mask-rule` script expects:

~~~
profile = disa_stig
remediation = /usr/share/scap-security-guide/bash/sle15-script-stig.sh
disabled-rules = partition_for_home,encrypted_partitions
~~~

So, *remediation* is missing and *disabled-rules* should contain rule names instead of ids.


## Solution

Adapt code to please the configuration expected by `mask-rule` script. Moreover, if no policy is enabled, then the configuration is not writen at all. 


## Testing

* Added new unit tests
* Tested manually
