### PR TITLE
Rules with identifiers and references

### DIFF
--- a/src/lib/y2security/clients/security_policy_proposal.rb
+++ b/src/lib/y2security/clients/security_policy_proposal.rb
@@ -454,7 +454,8 @@ module Y2Security
         # @param rules [Array<Y2Security::SecurityPolicies::Rule>] Rules to display
         # @return [String]
         def rules_list(rules)
-          items = rules.sort_by(&:id).map { |r| RulePresenter.new(r, links_builder).to_html }
+          rules = rules.sort_by { |r| r.identifiers.first }
+          items = rules.map { |r| RulePresenter.new(r, links_builder).to_html }
 
           Yast::HTML.List(items)
         end
@@ -477,10 +478,10 @@ module Y2Security
 
         # @return [String]
         def to_html
-          return message if actions.none?
+          second_line = (rule.identifiers + rule.references).join(", ")
+          second_line << " (#{actions.join(", ")})" if actions.any?
 
-          all_actions = actions.join(", ")
-          "#{message} (#{all_actions})"
+          rule.description + Yast::HTML.Newline + second_line
         end
 
       private
@@ -492,15 +493,11 @@ module Y2Security
         attr_reader :links_builder
 
         # @see #to_html
-        # @return [String]
-        def message
-          "#{rule.id} #{rule.description}"
-        end
-
-        # @see #to_html
         # @return [Array<String>]
         def actions
-          rule_actions = [toggle_action]
+          rule_actions = []
+          # Disabling rule is not offered for now.
+          # rule_actions << toggle_action
           rule_actions << fix_action if rule.enabled?
 
           rule_actions.compact

--- a/src/lib/y2security/clients/security_policy_proposal.rb
+++ b/src/lib/y2security/clients/security_policy_proposal.rb
@@ -495,11 +495,8 @@ module Y2Security
         # @see #to_html
         # @return [Array<String>]
         def actions
-          rule_actions = []
-          # Disabling rule is not offered for now.
-          # rule_actions << toggle_action
-          rule_actions << fix_action if rule.enabled?
-
+          # Disabling rule is not offered for now
+          rule_actions = rule.enabled? ? [fix_action] : []
           rule_actions.compact
         end
 

--- a/src/lib/y2security/security_policies/bootloader_password_rule.rb
+++ b/src/lib/y2security/security_policies/bootloader_password_rule.rb
@@ -27,22 +27,26 @@ module Y2Security
       def initialize
         textdomain "security"
 
-        # DISA STIG defines a rule for UEFI (SLES-15-010200) and another rule for non-UEFI
-        # (SLES-15-010190). The condition to check both rules in YaST is exactly the same, so let's
-        # simply adapt the rule name and ID according to the system type.
-        if Y2Storage::Arch.new.efiboot?
-          name = "grub2_uefi_password"
-          id = "SLES-15-010200"
-        else
-          name = "grub2_password"
-          id = "SLES-15-010190"
-        end
-
         # TRANSLATORS: security policy rule
         description = _("Boot loader must be protected by password and menu editing must be " \
           "restricted")
 
-        super(name, id: id, description: description, scope: :bootloader)
+        # DISA STIG defines a rule for UEFI (SLES-15-010200) and another rule for non-UEFI
+        # (SLES-15-010190). The condition to check both rules in YaST is exactly the same, so let's
+        # simply adapt the rule info according to the system type.
+        if Y2Storage::Arch.new.efiboot?
+          super("grub2_uefi_password",
+            identifiers: ["CCE-83275-8"],
+            references:  ["SLES-15-010200"],
+            description: description,
+            scope:       :bootloader)
+        else
+          super("grub2_password",
+            identifiers: ["CCE-83274-1"],
+            references:  ["SLES-15-010190"],
+            description: description,
+            scope:       :bootloader)
+        end
       end
 
       # @see Rule#pass?

--- a/src/lib/y2security/security_policies/disa_stig_policy.rb
+++ b/src/lib/y2security/security_policies/disa_stig_policy.rb
@@ -19,12 +19,12 @@
 
 require "yast"
 require "y2security/security_policies/policy"
-require "y2security/security_policies/bootloader_password_rule"
-require "y2security/security_policies/firewall_enabled_rule"
-require "y2security/security_policies/missing_encryption_rule"
-require "y2security/security_policies/missing_mount_point_rule"
+require "y2security/security_policies/separate_mount_point_rule"
 require "y2security/security_policies/separate_filesystem_rule"
 require "y2security/security_policies/filesystem_size_rule"
+require "y2security/security_policies/encrypted_filesystems_rule"
+require "y2security/security_policies/bootloader_password_rule"
+require "y2security/security_policies/firewall_enabled_rule"
 require "y2security/security_policies/no_wireless_rule"
 require "y2storage/disk_size"
 
@@ -49,16 +49,24 @@ module Y2Security
 
       def rules
         @rules ||= [
-          MissingMountPointRule.new("partition_for_home", "SLES-15-040200", "/home"),
-          MissingMountPointRule.new("partition_for_var", "SLES-15-040210", "/var"),
-          SeparateFilesystemRule.new("partition_for_var_log_audit",
-            "SLES-15-030810", "/var/log/audit"),
+          SeparateMountPointRule.new("partition_for_home", "/home",
+            identifiers: ["CCE-85639-3"],
+            references:  ["SLES-15-040200"]),
+          SeparateMountPointRule.new("partition_for_var", "/var",
+            identifiers: ["CCE-85640-1"],
+            references:  ["SLES-15-040210"]),
+          SeparateFilesystemRule.new("partition_for_var_log_audit", "/var/log/audit",
+            identifiers: ["CCE-85618-7"],
+            references:  ["SLES-15-030810"]),
           FilesystemSizeRule.new("auditd_audispd_configure_sufficiently_large_partition",
-            "SLES-15-030660", "/var/log/audit", min_size: Y2Storage::DiskSize.MiB(100)),
-          MissingEncryptionRule.new,
-          NoWirelessRule.new,
+            "/var/log/audit",
+            min_size:    Y2Storage::DiskSize.MiB(100),
+            identifiers: ["CCE-85697-1"],
+            references:  ["SLES-15-030660"]),
+          EncryptedFilesystemsRule.new,
+          BootloaderPasswordRule.new,
           FirewallEnabledRule.new,
-          BootloaderPasswordRule.new
+          NoWirelessRule.new
         ]
       end
     end

--- a/src/lib/y2security/security_policies/encrypted_filesystems_rule.rb
+++ b/src/lib/y2security/security_policies/encrypted_filesystems_rule.rb
@@ -22,15 +22,19 @@ require "y2storage"
 
 module Y2Security
   module SecurityPolicies
-    # Rule to check that all file systems are encrypted (except /boot/efi) (SLES-15-010330).
-    class MissingEncryptionRule < Rule
+    # Rule to check that all file systems are encrypted (except /boot/efi)
+    class EncryptedFilesystemsRule < Rule
       def initialize
         textdomain "security"
 
         # TRANSLATORS: Security policy rule
         description = _("All file systems must be encrypted")
 
-        super("encrypt_partitions", id: "SLES-15-010330", description: description, scope: :storage)
+        super("encrypt_partitions",
+          identifiers: ["CCE-85719-3"],
+          references:  ["SLES-15-010330"],
+          description: description,
+          scope:       :storage)
       end
 
       # @see Rule#pass?

--- a/src/lib/y2security/security_policies/filesystem_size_rule.rb
+++ b/src/lib/y2security/security_policies/filesystem_size_rule.rb
@@ -34,21 +34,31 @@ module Y2Security
       # @return [Y2Storage::DiskSize]
       attr_reader :min_size
 
-      # @param name [String] Rule name
-      # @param id [String] Rule ID
-      # @param mount_path [String] Mount path for the file system to check
-      # @param min_size [Y2Storage::DiskSize] Minimum size the file system should have
-      def initialize(name, id, mount_path, min_size: nil)
+      # Constructor
+      #
+      # @param id [String] See {Rule#id}
+      # @param mount_path [String] See {#mount_path}
+      # @param min_size [Y2Storage::DiskSize] See {#min_size}
+      # @param identifiers [Array<String>] See {Rule#identifiers}
+      # @param references [Array<String>] See {Rule#references}
+      def initialize(id, mount_path, min_size: nil, identifiers: [], references: [])
         textdomain "security"
 
-        @mount_path = mount_path
-        @min_size = min_size || Y2Storage::DiskSize.new(0)
+        min_size ||= Y2Storage::DiskSize.new(0)
+
         description = format(
           # TRANSLATORS: security policy rule, %s is a placeholder.
           _("The minimum size for the file system %s must be %s"), mount_path, min_size
         )
 
-        super(name, id: id, description: description, scope: :storage)
+        super(id,
+          identifiers: identifiers,
+          references:  references,
+          description: description,
+          scope:       :storage)
+
+        @mount_path = mount_path
+        @min_size = min_size
       end
 
       # @see Rule#pass?

--- a/src/lib/y2security/security_policies/firewall_enabled_rule.rb
+++ b/src/lib/y2security/security_policies/firewall_enabled_rule.rb
@@ -21,7 +21,7 @@ require "y2security/security_policies/rule"
 
 module Y2Security
   module SecurityPolicies
-    # Rule to verify that the firewall is enabled (SLES-15-010220).
+    # Rule to verify that the firewall is enabled
     class FirewallEnabledRule < Rule
       def initialize
         textdomain "security"
@@ -30,7 +30,10 @@ module Y2Security
         description = _("Firewall must be enabled")
 
         super("service_firewalld_enabled",
-          id: "SLES-15-010220", description: description, scope: :security)
+          identifiers: ["CCE-85751-6"],
+          references:  ["SLES-15-010220"],
+          description: description,
+          scope:       :security)
       end
 
       # @see Rule#pass?

--- a/src/lib/y2security/security_policies/manager.rb
+++ b/src/lib/y2security/security_policies/manager.rb
@@ -130,7 +130,7 @@ module Y2Security
         file = CFA::SsgApply.load
         file.profile = policy.id.to_s
         file.remediation = policy.remediation
-        file.disabled_rules = policy.rules.reject(&:enabled?).map(&:name)
+        file.disabled_rules = policy.rules.reject(&:enabled?).map(&:id)
         file.save
       end
 

--- a/src/lib/y2security/security_policies/no_wireless_rule.rb
+++ b/src/lib/y2security/security_policies/no_wireless_rule.rb
@@ -23,7 +23,7 @@ require "y2network/startmode"
 
 module Y2Security
   module SecurityPolicies
-    # Rule to deactivate wireless network interfaces (SLES-15-010380).
+    # Rule to deactivate wireless network interfaces
     class NoWirelessRule < Rule
       def initialize
         textdomain "security"
@@ -32,7 +32,10 @@ module Y2Security
         description = _("Wireless network interfaces must be deactivated")
 
         super("wireless_disable_interfaces",
-          id: "SLES-15-010380", description: description, scope: :network)
+          identifiers: ["CCE-83286-5"],
+          references:  ["SLES-15-010380"],
+          description: description,
+          scope:       :network)
       end
 
       # @see Rule#pass?

--- a/src/lib/y2security/security_policies/rule.rb
+++ b/src/lib/y2security/security_policies/rule.rb
@@ -28,11 +28,25 @@ module Y2Security
     class Rule
       include Yast::I18n
 
-      # @return [String] Rule name
-      attr_reader :name
-
-      # @return [String] Rule ID
+      # Rule ID
+      #
+      # Contains the rule ID as defined by the Scap Security Guided without the prefix
+      # "xccdf_org.ssgproject.content_rule_".
+      # For example, for a rule with ID "xccdf_org.ssgproject.content_rule_partition_for_home" the
+      # value would be "partition_for_home".
+      #
+      # @return [String]
       attr_reader :id
+
+      # Rule identifiers (e.g., "CCE-85639-3")
+      #
+      # @return [Array<String>]
+      attr_reader :identifiers
+
+      # Rule references (e.g., "SLES-15-040200", "SV-235004r622137_rule", etc)
+      #
+      # @return [Array<String>]
+      attr_reader :references
 
       # @return [String] Rule description
       attr_reader :description
@@ -40,13 +54,15 @@ module Y2Security
       # @return [Symbol] Scope to apply the rule to
       attr_reader :scope
 
-      # @param name [String] Rule name (e.g., "partition_for_home")
-      # @param id [String] Rule ID (e.g., "SLES-15-010190")
-      # @param description [String] Rule description
-      # @param scope [Symbol] Scope
-      def initialize(name, id: nil, description: nil, scope: nil)
-        @name = name
+      # @param id [String] See {#id}
+      # @param identifiers [Array<String>] See {#identifiers}
+      # @param references [Array<String>] See {#references}
+      # @param description [String] See {#description}
+      # @param scope [Symbol] See {#scope}
+      def initialize(id, identifiers: [], references: [], description: nil, scope: nil)
         @id = id
+        @identifiers = identifiers
+        @references = references
         @description = description
         @scope = scope
         @enabled = true

--- a/src/lib/y2security/security_policies/rule.rb
+++ b/src/lib/y2security/security_policies/rule.rb
@@ -30,7 +30,7 @@ module Y2Security
 
       # Rule ID
       #
-      # Contains the rule ID as defined by the Scap Security Guided without the prefix
+      # Contains the rule ID as defined by the SCAP Security Guided without the prefix
       # "xccdf_org.ssgproject.content_rule_".
       # For example, for a rule with ID "xccdf_org.ssgproject.content_rule_partition_for_home" the
       # value would be "partition_for_home".

--- a/src/lib/y2security/security_policies/separate_filesystem_rule.rb
+++ b/src/lib/y2security/security_policies/separate_filesystem_rule.rb
@@ -28,17 +28,25 @@ module Y2Security
       # @return [String]
       attr_reader :mount_path
 
-      # @param name [String] Rule name
-      # @param id [String] Rule ID
-      # @param mount_path [String] Mount path for the file system to check
-      def initialize(name, id, mount_path)
+      # Constructor
+      #
+      # @param id [String] See {Rule#id}
+      # @param mount_path [String] See {#mount_path}
+      # @param identifiers [Array<String>] See {Rule#identifiers}
+      # @param references [Array<String>] See {Rule#references}
+      def initialize(id, mount_path, identifiers: [], references: [])
         textdomain "security"
 
-        @mount_path = mount_path
         # TRANSLATORS: security policy rule, %s is a placeholder.
         description = format(_("There must be a separate file system for %s"), mount_path)
 
-        super(name, id: id, description: description, scope: :storage)
+        super(id,
+          identifiers: identifiers,
+          references:  references,
+          description: description,
+          scope:       :storage)
+
+        @mount_path = mount_path
       end
 
       # @see Rule#pass?

--- a/src/lib/y2security/security_policies/separate_mount_point_rule.rb
+++ b/src/lib/y2security/security_policies/separate_mount_point_rule.rb
@@ -23,21 +23,29 @@ require "y2storage"
 module Y2Security
   module SecurityPolicies
     # Rule to check whether there is a separate mount point for a given path
-    class MissingMountPointRule < Rule
-      # @return [String] Mount point to check
-      attr_reader :mount_point
+    class SeparateMountPointRule < Rule
+      # @return [String] Mount path to check
+      attr_reader :mount_path
 
-      # @param name [String] Rule name
-      # @param id [String] Rule ID
-      # @param mount_point [String] Mount point to check
-      def initialize(name, id, mount_point)
+      # Constructor
+      #
+      # @param id [String] See {Rule#id}
+      # @param mount_path [String] See {#mount_path}
+      # @param identifiers [Array<String>] See {Rule#identifiers}
+      # @param references [Array<String>] See {Rule#references}
+      def initialize(id, mount_path, identifiers: [], references: [])
         textdomain "security"
 
-        @mount_point = mount_point
         # TRANSLATORS: security policy rule
-        description = format(_("There must be a separate mount point for %s"), mount_point)
+        description = format(_("There must be a separate mount point for %s"), mount_path)
 
-        super(name, id: id, description: description, scope: :storage)
+        super(id,
+          identifiers: identifiers,
+          references:  references,
+          description: description,
+          scope:       :storage)
+
+        @mount_path = mount_path
       end
 
       # @see Rule#pass?
@@ -45,7 +53,7 @@ module Y2Security
         devicegraph = target_config.storage
         paths = devicegraph.mount_points.map(&:path)
 
-        paths.include?(mount_point)
+        paths.include?(mount_path)
       end
     end
   end

--- a/src/lib/y2security/security_policies/unknown_rule.rb
+++ b/src/lib/y2security/security_policies/unknown_rule.rb
@@ -31,11 +31,11 @@ module Y2Security
     class UnknownRule < Rule
       include Yast::I18n
 
-      # @param name [String] Rule name
-      def initialize(name)
+      # @param id [String] see {Rule#id}
+      def initialize(id)
         textdomain "security"
 
-        super(name, description: _("Unknown rule"), scope: :unknown)
+        super(id, description: _("Unknown rule"), scope: :unknown)
       end
 
       # Unknown rules are always considered as passing.

--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -958,10 +958,10 @@ module Yast
         end
 
         manager.enable_policy(policy)
-        section.disabled_rules.each do |rule_name|
-          rule = policy.rules.find { |r| r.name == rule_name }
+        section.disabled_rules.each do |rule_id|
+          rule = policy.rules.find { |r| r.id == rule_id }
           if rule.nil?
-            rule = Y2Security::SecurityPolicies::UnknownRule.new(rule_name)
+            rule = Y2Security::SecurityPolicies::UnknownRule.new(rule_id)
             policy.rules << rule
           end
           rule&.disable

--- a/test/security_test.rb
+++ b/test/security_test.rb
@@ -823,13 +823,13 @@ module Yast
 
         it "disables the unwanted rules" do
           subject.Import("SECURITY_POLICIES" => profile)
-          rule = policy.rules.find { |r| r.name == "partition_for_home" }
+          rule = policy.rules.find { |r| r.id == "partition_for_home" }
           expect(rule).to_not be_enabled
         end
 
         it "adds the unknown rules as disabled" do
           subject.Import("SECURITY_POLICIES" => profile)
-          rule = policy.rules.find { |r| r.name == "audit_rules_session_events_btmp" }
+          rule = policy.rules.find { |r| r.id == "audit_rules_session_events_btmp" }
           expect(rule).to be_a(Y2Security::SecurityPolicies::UnknownRule)
           expect(rule).to_not be_enabled
         end

--- a/test/y2security/clients/security_policy_proposal_test.rb
+++ b/test/y2security/clients/security_policy_proposal_test.rb
@@ -108,8 +108,8 @@ describe Y2Security::Clients::SecurityPolicyProposal do
           )
         end
 
-        it "includes a link to disable the rule" do
-          expect(subject.make_proposal({})).to include(
+        it "does not include a link to disable the rule" do
+          expect(subject.make_proposal({})).to_not include(
             "preformatted_proposal" => %r{<a href=.*>disable rule</a>}
           )
         end
@@ -173,8 +173,8 @@ describe Y2Security::Clients::SecurityPolicyProposal do
           )
         end
 
-        it "includes a link to enable the rule" do
-          expect(subject.make_proposal({})).to include(
+        it "does not include a link to enable the rule" do
+          expect(subject.make_proposal({})).to_not include(
             "preformatted_proposal" => %r{<a href=.*>enable rule</a>}
           )
         end

--- a/test/y2security/clients/security_policy_proposal_test.rb
+++ b/test/y2security/clients/security_policy_proposal_test.rb
@@ -39,7 +39,11 @@ end
 class DummyRule < Y2Security::SecurityPolicies::Rule
   def initialize
     textdomain "security"
-    super("dummy_rule", id: "SLES-15-000000", description: _("Dummy rule"), scope: :network)
+    super("dummy_rule",
+      identifiers: ["CCE-12345-67"],
+      references:  ["SLES-15-000000"],
+      description: _("Dummy rule"),
+      scope:       :network)
   end
 end
 

--- a/test/y2security/security_policies/bootloader_password_rule_test.rb
+++ b/test/y2security/security_policies/bootloader_password_rule_test.rb
@@ -32,12 +32,12 @@ describe Y2Security::SecurityPolicies::BootloaderPasswordRule do
 
   let(:bootloader) { Bootloader::NoneBootloader.new }
 
-  describe "#name" do
+  describe "#id" do
     context "in a UEFI system" do
       let(:efiboot) { true }
 
       it "returns grub2_uefi_password" do
-        expect(subject.name).to eq("grub2_uefi_password")
+        expect(subject.id).to eq("grub2_uefi_password")
       end
     end
 
@@ -45,25 +45,43 @@ describe Y2Security::SecurityPolicies::BootloaderPasswordRule do
       let(:efiboot) { false }
 
       it "returns grub2_password" do
-        expect(subject.name).to eq("grub2_password")
+        expect(subject.id).to eq("grub2_password")
       end
     end
   end
 
-  describe "#id" do
+  describe "#identifiers" do
     context "in a UEFI system" do
       let(:efiboot) { true }
 
-      it "returns SLES-15-010200" do
-        expect(subject.id).to eq("SLES-15-010200")
+      it "contains CCE-83275-8" do
+        expect(subject.identifiers).to contain_exactly("CCE-83275-8")
       end
     end
 
     context "in a non-UEFI system" do
       let(:efiboot) { false }
 
-      it "returns SLES-15-010190" do
-        expect(subject.id).to eq("SLES-15-010190")
+      it "contains CCE-83274-1" do
+        expect(subject.identifiers).to contain_exactly("CCE-83274-1")
+      end
+    end
+  end
+
+  describe "#references" do
+    context "in a UEFI system" do
+      let(:efiboot) { true }
+
+      it "contains SLES-15-010200" do
+        expect(subject.references).to contain_exactly("SLES-15-010200")
+      end
+    end
+
+    context "in a non-UEFI system" do
+      let(:efiboot) { false }
+
+      it "contains SLES-15-010190" do
+        expect(subject.references).to contain_exactly("SLES-15-010190")
       end
     end
   end

--- a/test/y2security/security_policies/disa_stig_policy_test.rb
+++ b/test/y2security/security_policies/disa_stig_policy_test.rb
@@ -37,16 +37,16 @@ describe Y2Security::SecurityPolicies::DisaStigPolicy do
 
     it "checks whether /home is on a separate mount point" do
       rule = subject.rules.find do |mp|
-        mp.is_a?(Y2Security::SecurityPolicies::MissingMountPointRule) &&
-          mp.mount_point == "/home"
+        mp.is_a?(Y2Security::SecurityPolicies::SeparateMountPointRule) &&
+          mp.mount_path == "/home"
       end
       expect(rule).to_not be_nil
     end
 
     it "checks whether /var is on a separate mount point" do
       rule = subject.rules.find do |mp|
-        mp.is_a?(Y2Security::SecurityPolicies::MissingMountPointRule) &&
-          mp.mount_point == "/var"
+        mp.is_a?(Y2Security::SecurityPolicies::SeparateMountPointRule) &&
+          mp.mount_path == "/var"
       end
       expect(rule).to_not be_nil
     end
@@ -70,7 +70,7 @@ describe Y2Security::SecurityPolicies::DisaStigPolicy do
 
     it "checks whether the file system is encrypted" do
       expect(subject.rules)
-        .to include(Y2Security::SecurityPolicies::MissingEncryptionRule)
+        .to include(Y2Security::SecurityPolicies::EncryptedFilesystemsRule)
     end
 
     it "checks that no wireless rules will be active" do

--- a/test/y2security/security_policies/filesystem_size_rule_test.rb
+++ b/test/y2security/security_policies/filesystem_size_rule_test.rb
@@ -24,20 +24,29 @@ require "y2storage"
 
 describe Y2Security::SecurityPolicies::FilesystemSizeRule do
   subject do
-    described_class.new("min_size", "SLES-15-030660", "/var/log/audit", min_size: min_size)
+    described_class.new("min_size", "/var/log/audit",
+      min_size:    min_size,
+      identifiers: ["CCE-85697-1"],
+      references:  ["SLES-15-030660"])
   end
 
   let(:min_size) { Y2Storage::DiskSize.MiB(100) }
 
-  describe "#name" do
-    it "returns the rule name" do
-      expect(subject.name).to eq("min_size")
+  describe "#id" do
+    it "returns the rule ID" do
+      expect(subject.id).to eq("min_size")
     end
   end
 
-  describe "#id" do
-    it "returns the rule ID" do
-      expect(subject.id).to eq("SLES-15-030660")
+  describe "identifiers" do
+    it "returns the rule identifiers" do
+      expect(subject.identifiers).to contain_exactly("CCE-85697-1")
+    end
+  end
+
+  describe "#references" do
+    it "returns the rule references" do
+      expect(subject.references).to contain_exactly("SLES-15-030660")
     end
   end
 

--- a/test/y2security/security_policies/firewall_enabled_rule_test.rb
+++ b/test/y2security/security_policies/firewall_enabled_rule_test.rb
@@ -33,18 +33,6 @@ describe Y2Security::SecurityPolicies::FirewallEnabledRule do
 
   let(:enabled) { true }
 
-  describe "#name" do
-    it "returns the rule name" do
-      expect(subject.name).to eq("service_firewalld_enabled")
-    end
-  end
-
-  describe "#id" do
-    it "returns the rule ID" do
-      expect(subject.id).to eq("SLES-15-010220")
-    end
-  end
-
   describe "#pass?" do
     context "when the firewall is enabled" do
       it "returns true" do

--- a/test/y2security/security_policies/separate_filesystem_rule_test.rb
+++ b/test/y2security/security_policies/separate_filesystem_rule_test.rb
@@ -22,17 +22,27 @@ require "y2security/security_policies/separate_filesystem_rule"
 require "y2security/security_policies/target_config"
 
 describe Y2Security::SecurityPolicies::SeparateFilesystemRule do
-  subject { described_class.new("partition_for_var_log_audit", "SLES-15-030810", "/var/log/audit") }
-
-  describe "#name" do
-    it "returns the rule name" do
-      expect(subject.name).to eq("partition_for_var_log_audit")
-    end
+  subject do
+    described_class.new("partition_for_var_log_audit", "/var/log/audit",
+      identifiers: ["CCE-85618-7"],
+      references:  ["SLES-15-030810"])
   end
 
   describe "#id" do
     it "returns the rule ID" do
-      expect(subject.id).to eq("SLES-15-030810")
+      expect(subject.id).to eq("partition_for_var_log_audit")
+    end
+  end
+
+  describe "identifiers" do
+    it "returns the rule identifiers" do
+      expect(subject.identifiers).to contain_exactly("CCE-85618-7")
+    end
+  end
+
+  describe "#references" do
+    it "returns the rule references" do
+      expect(subject.references).to contain_exactly("SLES-15-030810")
     end
   end
 

--- a/test/y2security/security_policies/unknown_rule_test.rb
+++ b/test/y2security/security_policies/unknown_rule_test.rb
@@ -23,15 +23,21 @@ require "y2security/security_policies/unknown_rule"
 describe Y2Security::SecurityPolicies::UnknownRule do
   subject { described_class.new("package_aide_installed") }
 
-  describe "#name" do
-    it "returns the rule name" do
-      expect(subject.name).to eq("package_aide_installed")
+  describe "#id" do
+    it "returns the rule ID" do
+      expect(subject.id).to eq("package_aide_installed")
     end
   end
 
-  describe "#id" do
-    it "returns nil" do
-      expect(subject.id).to be_nil
+  describe "#identifiers" do
+    it "returns an empty list" do
+      expect(subject.identifiers).to eq([])
+    end
+  end
+
+  describe "#references" do
+    it "returns an empty list" do
+      expect(subject.references).to eq([])
     end
   end
 


### PR DESCRIPTION
## Problem

Rule CCE identifier is not show.

https://trello.com/c/wHVROKfC/3126-1-display-both-cce-and-sles-15-identifiers-for-each-stig-rule


## Solution

Show CCE identifier and SUSE reference in a second line for each rule.

Note: disabling rule is not offered any more.

## Testing

- Added unit tests
- Tested manually


## Screenshots

![Screenshot from 2022-09-30 16-12-20](https://user-images.githubusercontent.com/1112304/193306472-6fb7ddf5-0924-431d-8542-c1b0c466768e.png)

![Screenshot from 2022-09-30 13-42-01](https://user-images.githubusercontent.com/1112304/193306476-b1c69918-deb1-47ba-9bbf-45b919ce7114.png)
