### PR TITLE
WIP: Help text for SecurityPolicyProposal

### DIFF
--- a/src/lib/y2security/clients/security_policy_proposal.rb
+++ b/src/lib/y2security/clients/security_policy_proposal.rb
@@ -90,6 +90,8 @@ module Y2Security
           toggle_rule(id)
         when "fix-rule"
           fix_rule(id)
+        when "set-scap-action"
+          policies_manager.scap_action = id.to_sym
         when "storage"
           result = open_client("inst_disk_proposal")
         when "bootloader"
@@ -109,7 +111,8 @@ module Y2Security
           rules = failing_rules[policy]
 
           presenter = PolicyPresenter.new(policy,
-            enabled: enabled, failing_rules: rules, links_builder: links_builder)
+            enabled: enabled, failing_rules: rules, links_builder: links_builder,
+            scap_action: policies_manager.scap_action)
 
           presenter.to_html
         end
@@ -127,7 +130,7 @@ module Y2Security
       def links
         policies_links = policies.map { |p| links_builder.links_for_policy(p) }
         rules_links = rules.map { |r| links_builder.links_for_rule(r) }
-        links = policies_links + rules_links
+        links = policies_links + rules_links + links_builder.links_for_scap_actions
 
         links.flatten.compact.uniq
       end
@@ -309,6 +312,14 @@ module Y2Security
           ]
         end
 
+        # Possible links to set the SCAP action
+        #
+        # @return [Array<String>]
+        def links_for_scap_actions
+          # TODO: turn this into an enum or something similar
+          [:none, :scan, :remediate].map { |a| scap_action_link(a) }
+        end
+
         # Link for toggling (enable or disable) a policy
         #
         # @param policy [SecurityPolicies::Policy]
@@ -341,6 +352,14 @@ module Y2Security
           end
         end
 
+        # Link to set the SCAP action after installation
+        #
+        # @param scap_action [Symbol] SCAP action
+        # @see Y2Security::SecurityPolicies::Manager#scap_action
+        def scap_action_link(scap_action)
+          build_link("set-scap-action", scap_action)
+        end
+
       private
 
         # @return [String]
@@ -365,26 +384,28 @@ module Y2Security
         # @param enabled [Boolean] Whether the policy is enabled
         # @param failing_rules [Array<SecurityPolicies::Rule>] Failing rules from the policy
         # @param links_builder [LinksBuilder] Object to build links
-        def initialize(policy, enabled:, failing_rules:, links_builder:)
+        def initialize(policy, enabled:, failing_rules:, links_builder:, scap_action:)
           textdomain "security"
 
           @policy = policy
           @policy_enabled = enabled
           @failing_rules = failing_rules
           @links_builder = links_builder
+          @scap_action = scap_action
         end
 
         # @return [String]
         def to_html
           toggle_link = links_builder.policy_toggle_link(policy)
 
-          if policy_enabled
+          sections = []
+          sections << if policy_enabled
             format(
               # TRANSLATORS: 'policy' is a security policy name; 'link' is just an HTML-like link
               _("%{policy} is enabled (<a href=\"%{link}\">disable</a>)"),
               policy: policy.name,
               link:   toggle_link
-            ) + rules_section
+            )
           else
             format(
               # TRANSLATORS: 'policy' is a security policy name; 'link' is just an HTML-like link
@@ -393,6 +414,12 @@ module Y2Security
               link:   toggle_link
             )
           end
+
+          if policy_enabled
+            sections << scap_section
+            sections << rules_section
+          end
+          sections.join
         end
 
       private
@@ -408,6 +435,9 @@ module Y2Security
 
         # @return [LinksBuilder]
         attr_reader :links_builder
+
+        # @return [Symbol]
+        attr_reader :scap_action
 
         # HTML section describing the failing and disabled rules
         #
@@ -458,6 +488,37 @@ module Y2Security
           items = rules.map { |r| RulePresenter.new(r, links_builder).to_html }
 
           Yast::HTML.List(items)
+        end
+
+        def scap_section
+          case scap_action
+          when :none
+            text = _("No SCAP scan will be performed on first boot")
+            actions = [:scan, :remediate]
+          when :scan
+            text = _("A full SCAP scan will be performed on first boot")
+            actions = [:none, :remediate]
+          else
+            text = _("A full SCAP remediation will be performed on first boot")
+            actions = [:none, :scan]
+          end
+
+          actions_links = actions.map { |a| scap_action_link(a) }.join(", ")
+          Yast::HTML.Para("#{text} (#{actions_links})")
+        end
+
+        def scap_action_link(action)
+          label =
+            case action
+            when :none
+              _("do nothing")
+            when :scan
+              _("scan only")
+            when :remediate
+              _("scan and remediate")
+            end
+
+          format("<a href=\"%s\">%s</a>", links_builder.scap_action_link(action), label)
         end
       end
 

--- a/src/lib/y2security/clients/security_policy_proposal.rb
+++ b/src/lib/y2security/clients/security_policy_proposal.rb
@@ -287,8 +287,8 @@ module Y2Security
       def help_text
         _(
           "<p><b>Security Policies</b</p>\n" \
-          "<p>This section allows to check whether the system to be installed will conform to " \
-          "the guidelines of a given security policy like the Security Technical Implementation " \
+          "<p>This section allows to configure the installed system to conform with the " \
+          "guidelines of a given security policy like the Security Technical Implementation " \
           "Guide (STIG) of the Defense Information Systems Agency (DISA).</p>\n" \
           "<p>Enabling a policy allows to configure the new system to execute a full security " \
           "scan using the OpenSCAP tools in the first boot. By default, that will generate a " \
@@ -296,13 +296,13 @@ module Y2Security
           "those that would need some kind of remediation. It's also possible to configure the " \
           "system to automatically try to apply a remedation for each failing rule. Note that " \
           "applying remediations can result in a system that is secure to the point of being " \
-          "unusable.</p>\n" \
+          "unusable for some use cases.</p>\n" \
           "<p>In some scenarios, some preliminary configuration may be needed before running " \
           "the OpenSCAP scan (eg. setting a tailoring file). Therefore it is also possible to " \
           "skip the scan during the first system boot.</p>" \
           "<p>Enabling a security policy will also cause the installer to check those rules that " \
           "are part of the policy but can hardly be remediated after installation. For each " \
-          "failing (ie. not fulfilled) rule the installer will display several well-known " \
+          "failing rule the installer will display several well-known " \
           "identifiers and a link to the functionality of the installer that can be used to " \
           "manually remediate the issue before proceeding with the installation.<p>"
         )

--- a/src/lib/y2security/clients/security_policy_proposal.rb
+++ b/src/lib/y2security/clients/security_policy_proposal.rb
@@ -64,7 +64,8 @@ module Y2Security
           "rich_text_title" => _("Security Policies"),
           # Menu entry label
           "menu_title"      => _("&Security Policies"),
-          "id"              => PROPOSAL_ID
+          "id"              => PROPOSAL_ID,
+          "help"            => help_text
         }
       end
 
@@ -281,6 +282,30 @@ module Y2Security
         Yast::Bootloader.proposed_cfg_changed = true if result == :next
 
         result
+      end
+
+      def help_text
+        _(
+          "<p><b>Security Policies</b</p>\n" \
+          "<p>This section allows to check whether the system to be installed will conform to " \
+          "the guidelines of a given security policy like the Security Technical Implementation " \
+          "Guide (STIG) of the Defense Information Systems Agency (DISA).</p>\n" \
+          "<p>Enabling a policy allows to configure the new system to execute a full security " \
+          "scan using the OpenSCAP tools in the first boot. By default, that will generate a " \
+          "report at <tt>/var/log/ssg-apply/</tt> specifying the rules that are fulfilled and " \
+          "those that would need some kind of remediation. It's also possible to configure the " \
+          "system to automatically try to apply a remedation for each failing rule. Note that " \
+          "applying remediations can result in a system that is secure to the point of being " \
+          "unusable.</p>\n" \
+          "<p>In some scenarios, some preliminary configuration may be needed before running " \
+          "the OpenSCAP scan (eg. setting a tailoring file). Therefore it is also possible to " \
+          "skip the scan during the first system boot.</p>" \
+          "<p>Enabling a security policy will also cause the installer to check those rules that " \
+          "are part of the policy but can hardly be remediated after installation. For each " \
+          "failing (ie. not fulfilled) rule the installer will display several well-known " \
+          "identifiers and a link to the functionality of the installer that can be used to " \
+          "manually remediate the issue before proceeding with the installation.<p>"
+        )
       end
 
       # Helper class to builds unique hyperlink IDs (by scoping actions with a dialog ID and adding

--- a/src/lib/y2security/security_policies/manager.rb
+++ b/src/lib/y2security/security_policies/manager.rb
@@ -30,9 +30,9 @@ module Y2Security
     # Class to manage security policies
     class Manager
       # @return [Symbol] action to perform after the installation. :remediate peforms a full
-      # remediation, :check just checks the policy and :none does nothing apart from installing
+      # remediation, :scan just scan the system and :none does nothing apart from installing
       # the package
-      attr_accessor :action
+      attr_accessor :scap_action
 
       class << self
         def instance
@@ -119,7 +119,7 @@ module Y2Security
       def write
         # Only one policy is expected to be enabled
         policy = policies.find { |p| enabled_policy?(p) }
-        return if policy.nil? || action == :none
+        return if policy.nil? || scap_action == :none
 
         write_config(policy)
         enable_service
@@ -139,7 +139,7 @@ module Y2Security
       def write_config(policy)
         file = CFA::SsgApply.load
         file.profile = policy.id.to_s
-        file.remediate = (action == :check) ? "no" : "yes"
+        file.remediate = (scap_action == :remediate) ? "yes" : "no"
         file.save
       end
 

--- a/test/y2security/security_policies/manager_test.rb
+++ b/test/y2security/security_policies/manager_test.rb
@@ -243,11 +243,11 @@ describe Y2Security::SecurityPolicies::Manager do
       allow(ssg_apply_file).to receive(:save)
 
       allow(disa_stig_policy).to receive(:rules).and_return(rules)
-      subject.action = action
+      subject.scap_action = scap_action
     end
 
     let(:ssg_apply_file) { CFA::SsgApply.new }
-    let(:action) { :none }
+    let(:scap_action) { :none }
 
     let(:rules) { [rule1, rule2, rule3] }
 
@@ -263,7 +263,7 @@ describe Y2Security::SecurityPolicies::Manager do
       it "writes failing rules in security_policy_failed_rules"
 
       context "when neither checks or remedation are enabled" do
-        let(:action) { :none }
+        let(:scap_action) { :none }
 
         it "does not write the configuration" do
           expect(ssg_apply_file).to_not receive(:save)
@@ -277,7 +277,7 @@ describe Y2Security::SecurityPolicies::Manager do
       end
 
       context "when checking the policy after installation is enabled" do
-        let(:action) { :check }
+        let(:scap_action) { :scan }
 
         it "disables ssg-apply remediation" do
           expect(ssg_apply_file).to receive(:save)
@@ -293,7 +293,7 @@ describe Y2Security::SecurityPolicies::Manager do
       end
 
       context "when full remediation is enabled" do
-        let(:action) { :remediate }
+        let(:scap_action) { :remediate }
 
         it "enables ssg-apply remediation" do
           expect(ssg_apply_file).to receive(:save)


### PR DESCRIPTION
## Problem

The new section "Security Policies" of the installation summary is too complex and it needs some help.

## Solution

Add a basic but comprehensive help text.

For a shorter version check #143.


## Other Pull Requests

This will only be displayed if this fix is present: https://github.com/yast/yast-installation/pull/1060

## Screenshot

![help2](https://user-images.githubusercontent.com/3638289/193765266-e3741055-f757-41d1-abca-6a2a246ecca0.png)



