### PR TITLE
Set the action to be performed by SCAP on first boot

### DIFF
--- a/src/lib/cfa/ssg_apply.rb
+++ b/src/lib/cfa/ssg_apply.rb
@@ -44,9 +44,7 @@ module CFA
     LENS = "simplevars.lns".freeze
     private_constant :LENS
 
-    attributes(
-      profile: "profile", remediation: "remediation", disabled_rules: "disabled-rules"
-    )
+    attributes(profile: "profile", remediate: "remediate")
 
     class << self
       # Loads a file
@@ -77,31 +75,6 @@ module CFA
       empty_elements = data.select(matcher).map { |e| e[:key] }
       empty_elements.each { |e| data.delete(e) }
       super
-    end
-
-    # Returns the list of disabled rules
-    #
-    # To add rules to the list, please use the #disabled_rules= method instead of
-    # adding rules to the value returned by this method.
-    #
-    # @return [Array<String>] List of disabled rules
-    def disabled_rules
-      @disabled_rules ||= generic_get("disabled-rules")
-        .to_s.split(",").freeze
-    end
-
-    # Sets the list of disabled rules
-    #
-    # @example Adding disabled rules
-    #   file = SsgApply.load
-    #   rules = file.disabled_rules
-    #   new_rule = Rule.new("SLES-15-000000", "My dummy rule", :unknown)
-    #   file.disabled_rules = rules + [new_rule]
-    #
-    # @param value [Array<String>] List of disabled rules IDs
-    def disabled_rules=(value)
-      @disabled_rules = nil
-      generic_set("disabled-rules", value.join(","))
     end
 
     # Determines whether the file is empty

--- a/src/lib/cfa/ssg_apply.rb
+++ b/src/lib/cfa/ssg_apply.rb
@@ -27,22 +27,19 @@ module CFA
   # @example Writing the base configuration
   #   file = SsgApply.new
   #   file.profile = "disa_stig"
-  #   file.remediation = "/usr/share/scap-security-guide/bash/sle15-script-stig.sh"
-  #   file.disabled_rules = ["partition_for_home"]
+  #   file.remedy = "yes"
   #   file.save
-  #
-  # @example Loading the configuration from a given file path
-  #   file = SsgApply.new(file_path: "/etc/ssg-apply/default.conf")
-  #   file.load
-  #   file.profile #=> "stig"
-  #   file.disabled_rules #=> []
   class SsgApply < BaseModel
     extend Yast::Logger
     include Yast::Logger
 
-    PATH = "/etc/ssg-apply/override.conf".freeze
+    # Original configuration file
+    DEFAULT_PATH = "/etc/ssg-apply/default.conf".freeze
+
+    # Configuration file used by YaST
+    OVERRIDE_PATH = "/etc/ssg-apply/override.conf".freeze
     LENS = "simplevars.lns".freeze
-    private_constant :LENS
+    private_constant :DEFAULT_PATH, :OVERRIDE_PATH, :LENS
 
     attributes(profile: "profile", remediate: "remediate")
 
@@ -52,7 +49,7 @@ module CFA
       # @param file_handler [#read,#write] an object able to read/write a string (like File)
       # @param file_path    [String] File path
       # @return [SsgApply] File with the already loaded content
-      def load(file_handler: Yast::TargetFile, file_path: PATH)
+      def load(file_handler: Yast::TargetFile, file_path: OVERRIDE_PATH)
         file = new(file_handler: file_handler, file_path: file_path)
         file.load
         file
@@ -61,11 +58,25 @@ module CFA
 
         file
       end
+
+      # Returns the default file path
+      #
+      # @return [String]
+      def default_file_path
+        DEFAULT_PATH
+      end
+
+      # Returns the YaST configuration file path
+      #
+      # @return [String]
+      def override_file_path
+        OVERRIDE_PATH
+      end
     end
 
     # @param file_handler [#read,#write] an object able to read/write a string (like File)
     # @param file_path    [String] File path
-    def initialize(file_handler: Yast::TargetFile, file_path: PATH)
+    def initialize(file_handler: Yast::TargetFile, file_path: OVERRIDE_PATH)
       super(AugeasParser.new(LENS), file_path, file_handler: file_handler)
     end
 

--- a/src/lib/cfa/ssg_apply.rb
+++ b/src/lib/cfa/ssg_apply.rb
@@ -36,7 +36,7 @@ module CFA
     # Original configuration file
     DEFAULT_PATH = "/etc/ssg-apply/default.conf".freeze
 
-    # Configuration file used by YaST
+    # Configuration file used for customizing the ssg-apply configuration
     OVERRIDE_PATH = "/etc/ssg-apply/override.conf".freeze
     LENS = "simplevars.lns".freeze
     private_constant :DEFAULT_PATH, :OVERRIDE_PATH, :LENS
@@ -66,7 +66,7 @@ module CFA
         DEFAULT_PATH
       end
 
-      # Returns the YaST configuration file path
+      # Returns the path of the file to customize the ssg-apply configuration
       #
       # @return [String]
       def override_file_path

--- a/src/lib/y2security/clients/security_policy_proposal.rb
+++ b/src/lib/y2security/clients/security_policy_proposal.rb
@@ -154,11 +154,11 @@ module Y2Security
 
       # Returns the warning level
       #
-      # Blocker if there are enabled failing rules
+      # Error if there are enabled failing rules
       #
-      # @return [Symbol] :blocker
+      # @return [Symbol,nil] :error or nil
       def warning_level
-        success? ? nil : :blocker
+        success? ? nil : :error
       end
 
       # Runs the security policies checks

--- a/src/lib/y2security/clients/security_policy_proposal.rb
+++ b/src/lib/y2security/clients/security_policy_proposal.rb
@@ -337,7 +337,7 @@ module Y2Security
         #
         # @return [Array<String>]
         def links_for_scap_actions
-          Y2Security::SecurityPolicies::Manager.scap_actions.map do |action|
+          Y2Security::SecurityPolicies::Manager.known_scap_actions.map do |action|
             scap_action_link(action)
           end
         end
@@ -421,14 +421,13 @@ module Y2Security
         def to_html
           toggle_link = links_builder.policy_toggle_link(policy)
 
-          sections = []
-          sections << if policy_enabled
+          if policy_enabled
             format(
               # TRANSLATORS: 'policy' is a security policy name; 'link' is just an HTML-like link
               _("%{policy} is enabled (<a href=\"%{link}\">disable</a>)"),
               policy: policy.name,
               link:   toggle_link
-            )
+            ) + scap_action_description + rules_section
           else
             format(
               # TRANSLATORS: 'policy' is a security policy name; 'link' is just an HTML-like link
@@ -437,12 +436,6 @@ module Y2Security
               link:   toggle_link
             )
           end
-
-          if policy_enabled
-            sections << scap_action_description
-            sections << rules_section
-          end
-          sections.join
         end
 
       private

--- a/src/lib/y2security/clients/security_policy_proposal.rb
+++ b/src/lib/y2security/clients/security_policy_proposal.rb
@@ -316,8 +316,9 @@ module Y2Security
         #
         # @return [Array<String>]
         def links_for_scap_actions
-          # TODO: turn this into an enum or something similar
-          [:none, :scan, :remediate].map { |a| scap_action_link(a) }
+          Y2Security::SecurityPolicies::Manager.scap_actions.map do |action|
+            scap_action_link(action)
+          end
         end
 
         # Link for toggling (enable or disable) a policy

--- a/src/lib/y2security/clients/security_policy_proposal.rb
+++ b/src/lib/y2security/clients/security_policy_proposal.rb
@@ -457,8 +457,9 @@ module Y2Security
         def failing_rules_section
           return nil if failing_rules.none?
 
-          Yast::HTML.Para(Yast::HTML.Colorize(_("The following rules are failing:"), "red")) +
-            rules_list(failing_rules)
+          Yast::HTML.Para(Yast::HTML.Colorize(
+            _("The following rules were already checked by the installer and are failing:"), "red")
+          ) + rules_list(failing_rules)
         end
 
         # HTML section describing the disabled rules

--- a/src/lib/y2security/clients/security_policy_proposal.rb
+++ b/src/lib/y2security/clients/security_policy_proposal.rb
@@ -457,9 +457,8 @@ module Y2Security
         def failing_rules_section
           return nil if failing_rules.none?
 
-          Yast::HTML.Para(Yast::HTML.Colorize(
-            _("The following rules were already checked by the installer and are failing:"), "red")
-          ) + rules_list(failing_rules)
+          msg = _("The following rules were already checked by the installer and are failing:")
+          Yast::HTML.Para(Yast::HTML.Colorize(msg, "red")) + rules_list(failing_rules)
         end
 
         # HTML section describing the disabled rules

--- a/src/lib/y2security/clients/security_policy_proposal.rb
+++ b/src/lib/y2security/clients/security_policy_proposal.rb
@@ -64,7 +64,8 @@ module Y2Security
           "rich_text_title" => _("Security Policies"),
           # Menu entry label
           "menu_title"      => _("&Security Policies"),
-          "id"              => PROPOSAL_ID
+          "id"              => PROPOSAL_ID,
+          "help"            => help_text
         }
       end
 
@@ -281,6 +282,26 @@ module Y2Security
         Yast::Bootloader.proposed_cfg_changed = true if result == :next
 
         result
+      end
+
+      def help_text
+        _(
+          "<p><b>Security Policies</b</p>\n" \
+          "<p>This section allows to configure the installed system to conform with the " \
+          "guidelines of a given security policy like the Security Technical Implementation " \
+          "Guide (STIG) of the Defense Information Systems Agency (DISA).</p>\n" \
+          "<p>Enabling a policy allows to configure the new system to execute a full security " \
+          "scan using the OpenSCAP tools in the first boot. By default, that will generate a " \
+          "report at <tt>/var/log/ssg-apply/</tt> listing the rules that would need some kind " \
+          "of remediation. The system can also be configured to automatically apply remediations " \
+          "right after the initial scan. Note that may lead to a system that is secure to the " \
+          "point of being unusable for some use cases. It is also possible to completely skip " \
+          "the automatic scan.</p>\n" \
+          "<p>Enabling a security policy will also cause the installer to check some rules that " \
+          "can hardly be remediated after installation. For each failing rule the installer will " \
+          "display several well-known identifiers and a link to the functionality of the " \
+          "installer that can be used to manually remediate the issue before installing.<p>"
+        )
       end
 
       # Helper class to builds unique hyperlink IDs (by scoping actions with a dialog ID and adding

--- a/src/lib/y2security/security_policies/disa_stig_policy.rb
+++ b/src/lib/y2security/security_policies/disa_stig_policy.rb
@@ -42,9 +42,8 @@ module Y2Security
         #   "Defense Information Systems Agency" is from the USA, https://disa.mil/
         #   STIG = Security Technical Implementation Guides
         name = _("Defense Information Systems Agency STIG")
-        remediation = "/usr/share/scap-security-guide/bash/sle15-script-stig.sh"
 
-        super(:disa_stig, name, remediation)
+        super(:disa_stig, name)
       end
 
       def rules

--- a/src/lib/y2security/security_policies/manager.rb
+++ b/src/lib/y2security/security_policies/manager.rb
@@ -24,8 +24,6 @@ require "cfa/ssg_apply"
 
 Yast.import "PackagesProposal"
 
-Yast.import "PackagesProposal"
-
 module Y2Security
   module SecurityPolicies
     # Class to manage security policies

--- a/src/lib/y2security/security_policies/manager.rb
+++ b/src/lib/y2security/security_policies/manager.rb
@@ -33,11 +33,22 @@ module Y2Security
       # @return [Symbol] action to perform after the installation. :remediate peforms a full
       # remediation, :scan just scan the system and :none does nothing apart from installing
       # the package
-      attr_accessor :scap_action
+      attr_reader :scap_action
+
+      class UnknownSCAPAction < StandardError; end
+
+      SCAP_ACTIONS = [:none, :scan, :remediate].freeze
 
       class << self
         def instance
           @instance ||= new
+        end
+
+        # Returns the know values for scap actions
+        #
+        # @return [Array<Symbol>]
+        def scap_actions
+          SCAP_ACTIONS
         end
       end
 
@@ -62,6 +73,12 @@ module Y2Security
         @last_result = {}
 
         enable_policies
+      end
+
+      def scap_action=(value)
+        raise UnknownSCAPAction unless self.class.scap_actions.include?(value)
+
+        @scap_action = value
       end
 
       # Returns the list of known security policies

--- a/src/lib/y2security/security_policies/manager.rb
+++ b/src/lib/y2security/security_policies/manager.rb
@@ -127,8 +127,6 @@ module Y2Security
 
         file = CFA::SsgApply.load
         file.profile = policy.id.to_s
-        file.remediation = policy.remediation
-        file.disabled_rules = policy.rules.reject(&:enabled?).map(&:id)
         file.save
       end
 

--- a/src/lib/y2security/security_policies/manager.rb
+++ b/src/lib/y2security/security_policies/manager.rb
@@ -30,9 +30,9 @@ module Y2Security
     # Class to manage security policies
     class Manager
       # @return [Symbol] action to perform after the installation. :remediate peforms a full
-      # remediation, :check just checks the policy and :none does nothing apart from installing
+      # remediation, :scan just scan the system and :none does nothing apart from installing
       # the package
-      attr_accessor :action
+      attr_accessor :scap_action
 
       class << self
         def instance
@@ -119,7 +119,7 @@ module Y2Security
       def write
         # Only one policy is expected to be enabled
         policy = policies.find { |p| enabled_policy?(p) }
-        return if policy.nil? || action == :none
+        return if policy.nil? || scap_action == :none
 
         write_config(policy)
         enable_service
@@ -139,7 +139,7 @@ module Y2Security
       def write_config(policy)
         file = CFA::SsgApply.load
         file.profile = policy.id.to_s
-        file.remediate = (action == :check) ? "no" : "yes"
+        file.remediate = (scap_action == :remediate) ? "yes" : "no"
         file.save
       end
 

--- a/src/lib/y2security/security_policies/manager.rb
+++ b/src/lib/y2security/security_policies/manager.rb
@@ -149,7 +149,6 @@ module Y2Security
         file.save
       end
 
-
       # Copies the default configuration file to the one used by YaST
       #
       def copy_default_config

--- a/src/lib/y2security/security_policies/manager.rb
+++ b/src/lib/y2security/security_policies/manager.rb
@@ -58,6 +58,7 @@ module Y2Security
       # ENV_SECURITY_POLICIES
       def initialize
         @enabled_policies = []
+        @scap_action = :scan
 
         enable_policies
       end

--- a/src/lib/y2security/security_policies/manager.rb
+++ b/src/lib/y2security/security_policies/manager.rb
@@ -30,9 +30,10 @@ module Y2Security
   module SecurityPolicies
     # Class to manage security policies
     class Manager
-      # @return [Symbol] action to perform after the installation. :remediate peforms a full
-      # remediation, :scan just scan the system and :none does nothing apart from installing
-      # the package
+      # @return [:none, :scan, :remediate] action to perform after the installation. `:remediate`
+      #   peforms a full remediation; `:scan` just scan the system and `:none` does nothing apart
+      #   from installing the package
+      # @see .known_scap_actions
       attr_reader :scap_action
 
       class UnknownSCAPAction < StandardError; end
@@ -44,10 +45,10 @@ module Y2Security
           @instance ||= new
         end
 
-        # Returns the know values for scap actions
+        # Returns the known values for scap actions
         #
         # @return [Array<Symbol>]
-        def scap_actions
+        def known_scap_actions
           SCAP_ACTIONS
         end
       end
@@ -76,7 +77,7 @@ module Y2Security
       end
 
       def scap_action=(value)
-        raise UnknownSCAPAction unless self.class.scap_actions.include?(value)
+        raise UnknownSCAPAction unless self.class.known_scap_actions.include?(value)
 
         @scap_action = value
       end

--- a/src/lib/y2security/security_policies/policy.rb
+++ b/src/lib/y2security/security_policies/policy.rb
@@ -35,18 +35,11 @@ module Y2Security
       # @return [String]
       attr_reader :name
 
-      # Path to the file provided by scap_security_guide to apply remediation for the policy
-      #
-      # @return [String]
-      attr_reader :remediation
-
       # @param id [Symbol]
       # @param name [String]
-      # @param remediation [String]
-      def initialize(id, name, remediation)
+      def initialize(id, name)
         @id = id
         @name = name
-        @remediation = remediation
       end
 
       # @param config [TargetConfig] Configuration to check

--- a/test/cfa/ssg_apply_test.rb
+++ b/test/cfa/ssg_apply_test.rb
@@ -59,13 +59,11 @@ describe CFA::SsgApply do
   describe "#save" do
     before do
       file.profile = profile
-      file.remediation = remediation
-      file.disabled_rules = disabled_rules
+      file.remediate = remediate
     end
 
     let(:profile) { "disa_stig" }
-    let(:remediation) { "/path/to/file.sh" }
-    let(:disabled_rules) { ["rule1", "rule2"] }
+    let(:remediate) { "yes" }
 
     it "writes the profile" do
       expect(file_handler).to receive(:write).with(anything, /profile = disa_stig/)
@@ -73,14 +71,8 @@ describe CFA::SsgApply do
       file.save
     end
 
-    it "writes the remediation" do
-      expect(file_handler).to receive(:write).with(anything, /remediation = \/path\/to\/file.sh/)
-
-      file.save
-    end
-
-    it "writes the disabled rules" do
-      expect(file_handler).to receive(:write).with(anything, /disabled-rules = rule1,rule2/)
+    it "writes the remediate value" do
+      expect(file_handler).to receive(:write).with(anything, /remediate = yes/)
 
       file.save
     end
@@ -97,24 +89,12 @@ describe CFA::SsgApply do
       end
     end
 
-    context "when the remediation is empty" do
-      let(:remediation) { "" }
+    context "when the remediate is empty" do
+      let(:remediate) { "" }
 
-      it "removes the remediation key" do
+      it "removes the remediate key" do
         expect(file_handler).to receive(:write) do |_, content|
-          expect(content).to_not include("remediation")
-        end
-
-        file.save
-      end
-    end
-
-    context "when disabled rules is empty" do
-      let(:disabled_rules) { [] }
-
-      it "removes the disabled-rules key" do
-        expect(file_handler).to receive(:write) do |_, content|
-          expect(content).to_not include("disabled-rules")
+          expect(content).to_not include("remediate")
         end
 
         file.save
@@ -126,31 +106,6 @@ describe CFA::SsgApply do
     it "returns the profile value" do
       file.load
       expect(file.profile).to eq("stig")
-    end
-  end
-
-  describe "#disabled_rules" do
-    context "when a 'disabled_rules' list is specified" do
-      let(:file_path) { File.join(DATA_PATH, "system/etc/ssg-apply/override.conf") }
-
-      it "returns an array containing the disabled rules" do
-        file.load
-        expect(file.disabled_rules).to eq(["partition_for_home", "encrypt_partitions"])
-      end
-    end
-
-    context "when no 'disabled_rules' list is specified" do
-      it "returns an empty array" do
-        expect(file.disabled_rules).to eq([])
-      end
-    end
-  end
-
-  describe "#disabled_rules=" do
-    it "sets the 'disabled-rules' key to a comma separated list" do
-      expect(file).to receive(:generic_set)
-        .with("disabled-rules", "rule_name1,rule_name2")
-      file.disabled_rules = ["rule_name1", "rule_name2"]
     end
   end
 end

--- a/test/y2security/clients/security_policy_proposal_test.rb
+++ b/test/y2security/clients/security_policy_proposal_test.rb
@@ -104,7 +104,7 @@ describe Y2Security::Clients::SecurityPolicyProposal do
 
         it "includes a failing rules section" do
           expect(subject.make_proposal({})).to include(
-            "preformatted_proposal" => /rules are failing:.*Dummy rule/
+            "preformatted_proposal" => /and are failing:.*Dummy rule/
           )
         end
 

--- a/test/y2security/clients/security_policy_proposal_test.rb
+++ b/test/y2security/clients/security_policy_proposal_test.rb
@@ -96,9 +96,9 @@ describe Y2Security::Clients::SecurityPolicyProposal do
           )
         end
 
-        it "returns :block as warning_level" do
+        it "returns :error as warning_level" do
           expect(subject.make_proposal({})).to include(
-            "warning_level" => :blocker
+            "warning_level" => :error
           )
         end
 

--- a/test/y2security/clients/security_policy_proposal_test.rb
+++ b/test/y2security/clients/security_policy_proposal_test.rb
@@ -28,7 +28,7 @@ require "bootloader/main_dialog"
 class DummyPolicy < Y2Security::SecurityPolicies::Policy
   def initialize
     textdomain "security"
-    super(:dummy, _("Dummy policy"), "/remediation.sh")
+    super(:dummy, _("Dummy policy"))
   end
 
   def rules

--- a/test/y2security/security_policies/manager_test.rb
+++ b/test/y2security/security_policies/manager_test.rb
@@ -243,11 +243,11 @@ describe Y2Security::SecurityPolicies::Manager do
       allow(ssg_apply_file).to receive(:save)
 
       allow(disa_stig_policy).to receive(:rules).and_return(rules)
-      subject.action = action
+      subject.scap_action = scap_action
     end
 
     let(:ssg_apply_file) { CFA::SsgApply.new }
-    let(:action) { :none }
+    let(:scap_action) { :none }
 
     let(:rules) { [rule1, rule2, rule3] }
 
@@ -263,7 +263,7 @@ describe Y2Security::SecurityPolicies::Manager do
       it "writes failing rules in security_policy_failed_rules"
 
       context "when neither checks or remedation are enabled" do
-        let(:action) { :none }
+        let(:scap_action) { :none }
 
         it "does not write the configuration" do
           expect(ssg_apply_file).to_not receive(:save)
@@ -277,7 +277,7 @@ describe Y2Security::SecurityPolicies::Manager do
       end
 
       context "when checking the policy after installation is enabled" do
-        let(:action) { :check }
+        let(:scap_action) { :scan }
 
         it "disables ssg-apply remediation" do
           expect(ssg_apply_file).to receive(:save)
@@ -293,7 +293,7 @@ describe Y2Security::SecurityPolicies::Manager do
       end
 
       context "when full remediation is enabled" do
-        let(:action) { :remediate }
+        let(:scap_action) { :remediate }
 
         it "enables ssg-apply remediation" do
           expect(ssg_apply_file).to receive(:save)

--- a/test/y2security/security_policies/manager_test.rb
+++ b/test/y2security/security_policies/manager_test.rb
@@ -251,6 +251,8 @@ describe Y2Security::SecurityPolicies::Manager do
   describe "#write" do
     before do
       allow(disa_stig_policy).to receive(:rules).and_return(rules)
+      allow(Y2Security::SecurityPolicies::TargetConfig).to receive(:new)
+        .and_return(target_config)
       subject.scap_action = scap_action
 
       allow(Yast::WFM).to receive(:scr_root).and_return(scr_root)
@@ -259,6 +261,7 @@ describe Y2Security::SecurityPolicies::Manager do
         File.join(DATA_PATH, "system", "etc", "ssg-apply", "default.conf"),
         default_file_path
       )
+
       allow(rule1).to receive(:pass?).and_return(false)
       allow(rule2).to receive(:pass?).and_return(false)
     end
@@ -267,9 +270,10 @@ describe Y2Security::SecurityPolicies::Manager do
     let(:scap_action) { :none }
     let(:default_file_path) { File.join(scr_root, "etc", "ssg-apply", "default.conf") }
     let(:override_file_path) { File.join(scr_root, "etc", "ssg-apply", "override.conf") }
-    let(:rule1) { Y2Security::SecurityPolicies::UnknownRule.new("rule1").tap(&:disable) }
+    let(:rule1) { Y2Security::SecurityPolicies::UnknownRule.new("rule1").tap(&:enable) }
     let(:rule2) { Y2Security::SecurityPolicies::UnknownRule.new("rule2").tap(&:enable) }
     let(:rule3) { Y2Security::SecurityPolicies::UnknownRule.new("rule3").tap(&:disable) }
+    let(:target_config) { instance_double(Y2Security::SecurityPolicies::TargetConfig) }
 
     let(:rules) { [rule1, rule2, rule3] }
     let(:target_config) do

--- a/test/y2security/security_policies/manager_test.rb
+++ b/test/y2security/security_policies/manager_test.rb
@@ -98,7 +98,7 @@ describe Y2Security::SecurityPolicies::Manager do
     end
 
     context "if the given policy is unknown" do
-      let(:policy) { Y2Security::SecurityPolicies::Policy.new(:unknown, "Unknown", "") }
+      let(:policy) { Y2Security::SecurityPolicies::Policy.new(:unknown, "Unknown") }
 
       it "does not enable the policy" do
         subject.enable_policy(policy)
@@ -265,14 +265,10 @@ describe Y2Security::SecurityPolicies::Manager do
         subject.enable_policy(disa_stig_policy)
       end
 
-      it "writes the profile, remediation and disabled rules in the ssg-apply config" do
+      it "writes the ssg-apply configuration file" do
         expect(ssg_apply_file).to receive(:save)
-
         subject.write_config
-
         expect(ssg_apply_file.profile).to eq("disa_stig")
-        expect(ssg_apply_file.remediation).to eq(disa_stig_policy.remediation)
-        expect(ssg_apply_file.disabled_rules).to contain_exactly("rule1", "rule3")
       end
     end
 

--- a/test/y2security/security_policies/manager_test.rb
+++ b/test/y2security/security_policies/manager_test.rb
@@ -67,6 +67,17 @@ describe Y2Security::SecurityPolicies::Manager do
     end
   end
 
+  describe "#scap_action" do
+    it "returns :scan by default" do
+      expect(subject.scap_action).to eq(:scan)
+    end
+
+    it "returns the given action" do
+      subject.scap_action = :remediate
+      expect(subject.scap_action).to eq(:remediate)
+    end
+  end
+
   describe "#policies" do
     it "returns all the known policies" do
       expect(subject.policies).to contain_exactly(disa_stig_policy)


### PR DESCRIPTION
## Summary

This PR adds support for setting the action to be performed using SCAP during the first boot, among other changes.

## Changes

* Allow setting an action for the first boot (*nothing*, *scan only* or *scan and remediate*).
* Report an error instead of blocking the installation when the security policy is not met.
* Changes in `ssg-apply` configuration:
  * Update the `remediate` value (`yes` for `scan and remediate`; `no` for `scan` only).
  * Do not write the remediation script and the list of disabled rules to the `ssg-apply` configuration.
  * Use `/etc/ssg-apply/default.conf` as base for the configuration file.
* Write the list of failing rules to `/var/log/YaST2/security_policies_failed_rules`.
* Add a help text specifying how the feature works.

## Screenshots

<details>
<summary>Summary including the new feature to set the SCAP action on first boot</summary>

![stig-scap-action](https://user-images.githubusercontent.com/15836/193746479-626ea8c6-ad39-443d-bf3b-43827aa3fc7b.png)
</details>

<details>
<summary>Help text explaining how the feature works</summary>

![stig-help-text](https://user-images.githubusercontent.com/15836/193802526-9bbd1d4a-9c4e-4f28-8c75-3756a959e274.png)

</details>

<details>
<summary>Warn the user but do not block the installation</summary>

![stig-error-stop](https://user-images.githubusercontent.com/15836/193745814-31ea1651-e57d-4dd1-a18f-1b6aae1283c8.png)
</details>

<details>
<summary>List of failed rules</summary>

![stig-failed-rules](https://user-images.githubusercontent.com/15836/193753020-cc845cfc-acc8-43a9-9624-c6b4c1f0b068.png)
</details>