### PR TITLE
Use "stig" as profile name for DISA STIG

### DIFF
--- a/src/lib/y2security/security_policies/disa_stig_policy.rb
+++ b/src/lib/y2security/security_policies/disa_stig_policy.rb
@@ -43,7 +43,7 @@ module Y2Security
         #   STIG = Security Technical Implementation Guides
         name = _("Defense Information Systems Agency STIG")
 
-        super(:disa_stig, name)
+        super(:stig, name)
       end
 
       def rules

--- a/src/lib/y2security/security_policies/manager.rb
+++ b/src/lib/y2security/security_policies/manager.rb
@@ -219,7 +219,7 @@ module Y2Security
       # @param value [String]
       # @return [Policy, nil]
       def policy_from_env(value)
-        return find_policy(:disa_stig) if value.match?(/\Adisa_stig\z/i)
+        return find_policy(:stig) if value.match?(/\Astig\z/i)
 
         log.warn("Security policy #{value} not found.")
         nil

--- a/test/security_test.rb
+++ b/test/security_test.rb
@@ -802,7 +802,7 @@ module Yast
         let(:profile) do
           [
             {
-              "name"           => "disa_stig",
+              "name"           => "stig",
               "disabled_rules" => [
                 "partition_for_home",
                 "audit_rules_session_events_btmp"

--- a/test/y2security/security_policies/manager_test.rb
+++ b/test/y2security/security_policies/manager_test.rb
@@ -59,7 +59,7 @@ describe Y2Security::SecurityPolicies::Manager do
     end
 
     context "when YAST_SECURITY_POLICIES contains a known policy" do
-      let(:env) { { "YAST_SECURITY_POLICIES" => "foo,Disa_Stig" } }
+      let(:env) { { "YAST_SECURITY_POLICIES" => "foo,Stig" } }
 
       it "enables the policy" do
         expect(subject.enabled_policies).to contain_exactly(disa_stig_policy)
@@ -86,7 +86,7 @@ describe Y2Security::SecurityPolicies::Manager do
 
   describe "#find_policy" do
     context "if there is a policy with the given id" do
-      let(:id) { :disa_stig }
+      let(:id) { :stig }
 
       it "returns the policy" do
         expect(subject.find_policy(id)).to eq(disa_stig_policy)
@@ -319,7 +319,7 @@ describe Y2Security::SecurityPolicies::Manager do
           subject.write
           apply_file = CFA::SsgApply.load
           expect(apply_file.remediate).to eq("no")
-          expect(apply_file.profile).to eq("disa_stig")
+          expect(apply_file.profile).to eq("stig")
         end
 
         it "enables the service" do
@@ -335,7 +335,7 @@ describe Y2Security::SecurityPolicies::Manager do
           subject.write
           apply_file = CFA::SsgApply.load
           expect(apply_file.remediate).to eq("yes")
-          expect(apply_file.profile).to eq("disa_stig")
+          expect(apply_file.profile).to eq("stig")
         end
 
         it "enables the service" do


### PR DESCRIPTION
## Problem

The profile "disa_stig" does not exists.

## Solution

Use `stig` instead of `disa_stig` as profile name for ssg-apply configuration.

