### PR TITLE
Fix hash vs keyword arguments in RSpec expectations (bsc#1204871)

### DIFF
--- a/package/yast2-security.changes
+++ b/package/yast2-security.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Nov  2 15:46:44 UTC 2022 - Martin Vidner <mvidner@suse.com>
+
+- Fix hash vs keyword arguments in RSpec expectations (bsc#1204871)
+- 4.5.2
+
+-------------------------------------------------------------------
 Tue Aug 23 08:41:45 UTC 2022 - David Diaz <dgonzalez@suse.com>
 
 - Do not crash when reading active LSM modules returns nil

--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-security
-Version:        4.5.1
+Version:        4.5.2
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/test/y2security/lsm/selinux_test.rb
+++ b/test/y2security/lsm/selinux_test.rb
@@ -273,9 +273,14 @@ describe Y2Security::LSM::Selinux do
     end
 
     it "resets the kernel params it knows" do
+      params = {
+        "lsm"       => :missing,
+        "security"  => :missing,
+        "enforcing" => :missing,
+        "selinux"   => :missing
+      }
       expect(Yast::Bootloader).to receive(:modify_kernel_params)
-        .with("lsm" => :missing, "security" => :missing,
-                "enforcing" => :missing, "selinux" => :missing)
+        .with(params)
       subject.reset_kernel_params
     end
   end


### PR DESCRIPTION
- https://bugzilla.opensuse.org/show_bug.cgi?id=1204871 "- [Staging] rubygem-rspec-* 3.12 breaks various yast modules build"
- see https://github.com/yast/yast-yast2/pull/1279 for details
