### PR TITLE
AutoYaST: adapt to the new schema of the security_policies section

### DIFF
--- a/src/autoyast-rnc/security.rnc
+++ b/src/autoyast-rnc/security.rnc
@@ -46,16 +46,12 @@ runlevel3_mandatory_services = element runlevel3_mandatory_services { STRING }
 runlevel5_extra_services = element runlevel5_extra_services { STRING }
 runlevel5_mandatory_services = element runlevel5_mandatory_services { STRING }
 smtpd_listen_remote = element smtpd_listen_remote { STRING }
-security_policies = element security_policies {
+security_policy = element security_policy {
     MAP,
     (
-      element action { "none" | "scan" | "remediate" }? &
-      enabled_policies?
+      element policy { STRING } &
+      element action { "none" | "scan" | "remediate" }?
     )
-}
-enabled_policies = element enabled_policies {
-    LIST,
-    element listentry { STRING }*
 }
 syslog_on_no_error = element syslog_on_no_error { STRING }
 system_gid_max = element system_gid_max { STRING }
@@ -115,7 +111,7 @@ y2_security =
   | runlevel3_mandatory_services
   | runlevel5_extra_services
   | runlevel5_mandatory_services
-  | security_policies
+  | security_policy
   | smtpd_listen_remote
   | syslog_on_no_error
   | system_gid_max

--- a/src/autoyast-rnc/security.rnc
+++ b/src/autoyast-rnc/security.rnc
@@ -46,20 +46,16 @@ runlevel3_mandatory_services = element runlevel3_mandatory_services { STRING }
 runlevel5_extra_services = element runlevel5_extra_services { STRING }
 runlevel5_mandatory_services = element runlevel5_mandatory_services { STRING }
 smtpd_listen_remote = element smtpd_listen_remote { STRING }
-disabled_rules = element disabled_rules {
-    LIST,
-    element listentry { STRING }*
-}
-security_policy = element (security_policy | listentry) {
+security_policies = element security_policies {
     MAP,
     (
-      element name { STRING }? &
-      disabled_rules?
+      element action { "none" | "scan" | "remediate" }? &
+      enabled_policies?
     )
 }
-security_policies = element security_policies {
+enabled_policies = element enabled_policies {
     LIST,
-    security_policy*
+    element listentry { STRING }*
 }
 syslog_on_no_error = element syslog_on_no_error { STRING }
 system_gid_max = element system_gid_max { STRING }

--- a/src/lib/y2security/autoinst_profile/security_policy_section.rb
+++ b/src/lib/y2security/autoinst_profile/security_policy_section.rb
@@ -24,32 +24,30 @@ module Y2Security
     # This class represents the <security_policy> section of an AutoYaST profile
     #
     # @example Enabling DISA STIG except one of the rules
-    #   <security_policies t="list">
-    #     <listitem>
-    #       <name>disa_stig</name>
-    #       <disabled_rules t="list">
-    #         <listitem>encrypt_partitions</listitem>
-    #       </disabled_rules>
-    #     </listitem>
+    #   <security_policies>
+    #     <action>none</action>
+    #     <enabled_policies t="list">
+    #       <listentry>stig</listentry>
+    #     </enabled_policies>
     #   </security_policies>
     class SecurityPolicySection < ::Installation::AutoinstProfile::SectionWithAttributes
       def self.attributes
         [
-          { name: :name },
-          { name: :disabled_rules }
+          { name: :action },
+          { name: :enabled_policies }
         ]
       end
 
       define_attr_accessors
 
-      # @!attribute name
-      #   @return [String] Policy name to apply
-      # @!attribute disabled_rules
-      #   @return [Array<String>] Name of the rules to ignore
+      # @!attribute action
+      #   @return [String,nil] SCAP action to apply on first boot ("none", "scan" or "remediate")
+      # @!attribute enabled_policies
+      #   @return [Array<String>] List of enabled policies
 
       def initialize(parent = nil)
         super
-        @disabled_rules = []
+        @enabled_policies = []
       end
 
       # Method used by {.new_from_hashes} to populate the attributes.
@@ -57,7 +55,7 @@ module Y2Security
       # @param hash [Hash] see {.new_from_hashes}
       def init_from_hashes(hash)
         super
-        @disabled_rules = hash["disabled_rules"] || []
+        @enabled_policies = hash["enabled_policies"] if hash.key?("enabled_policies")
       end
     end
   end

--- a/src/lib/y2security/autoinst_profile/security_policy_section.rb
+++ b/src/lib/y2security/autoinst_profile/security_policy_section.rb
@@ -24,17 +24,15 @@ module Y2Security
     # This class represents the <security_policy> section of an AutoYaST profile
     #
     # @example Enabling DISA STIG except one of the rules
-    #   <security_policies>
+    #   <security_policy>
     #     <action>none</action>
-    #     <enabled_policies t="list">
-    #       <listentry>stig</listentry>
-    #     </enabled_policies>
-    #   </security_policies>
+    #     <name>stig</name>
+    #   </security_policy>
     class SecurityPolicySection < ::Installation::AutoinstProfile::SectionWithAttributes
       def self.attributes
         [
           { name: :action },
-          { name: :enabled_policies }
+          { name: :policy }
         ]
       end
 
@@ -42,21 +40,8 @@ module Y2Security
 
       # @!attribute action
       #   @return [String,nil] SCAP action to apply on first boot ("none", "scan" or "remediate")
-      # @!attribute enabled_policies
-      #   @return [Array<String>] List of enabled policies
-
-      def initialize(parent = nil)
-        super
-        @enabled_policies = []
-      end
-
-      # Method used by {.new_from_hashes} to populate the attributes.
-      #
-      # @param hash [Hash] see {.new_from_hashes}
-      def init_from_hashes(hash)
-        super
-        @enabled_policies = hash["enabled_policies"] if hash.key?("enabled_policies")
-      end
+      # @!attribute policy
+      #   @return [String,nil] Enabled policy
     end
   end
 end

--- a/src/lib/y2security/autoinst_profile/security_section.rb
+++ b/src/lib/y2security/autoinst_profile/security_section.rb
@@ -28,21 +28,17 @@ module Y2Security
     # <security>
     #   <selinux_mode>enforcing</selinux_mode>
     #   <lsm_select>selinux</lsm_select>
-    #   <security_policies t="list">
-    #     <listitem>
-    #       <name>disa_stig</name>
-    #       <disabled_rules t="list">
-    #         <listitem>SLES-15-020400</listitem>
-    #       </disabled_rules>
-    #     </listitem>
-    #   </security_policies>
+    #   <security_policy>
+    #     <policy>stig</policy>
+    #     <action>remediate</action>
+    #   </security_policy>
     # </security>
     class SecuritySection < ::Installation::AutoinstProfile::SectionWithAttributes
       def self.attributes
         [
           { name: :selinux_mode },
           { name: :lsm_select },
-          { name: :security_policies }
+          { name: :security_policy }
         ]
       end
 
@@ -53,13 +49,15 @@ module Y2Security
       # @!attribute lsm_select
       #   @return [String] Major Linux Security Module to be used.
       #     Possible values: apparmor, selinux, none
+      # @!attribute security_policy
+      #   @return [SecurityPolicy] Security policy section
 
       # Constructor
       #
       # @param parent [SectionWithAttributes] Parent section
       def initialize(parent = nil)
         super
-        @security_policies = SecurityPolicySection.new
+        @security_policy = SecurityPolicySection.new
       end
 
       # Method used by {.new_from_hashes} to populate the attributes.
@@ -67,7 +65,9 @@ module Y2Security
       # @param hash [Hash] see {.new_from_hashes}
       def init_from_hashes(hash)
         super
-        @security_policies = SecurityPolicySection.new_from_hashes(hash["security_policies"], self)
+        return unless hash.key?("security_policy")
+
+        @security_policy = SecurityPolicySection.new_from_hashes(hash["security_policy"], self)
       end
     end
   end

--- a/src/lib/y2security/autoinst_profile/security_section.rb
+++ b/src/lib/y2security/autoinst_profile/security_section.rb
@@ -59,7 +59,7 @@ module Y2Security
       # @param parent [SectionWithAttributes] Parent section
       def initialize(parent = nil)
         super
-        @security_policies = []
+        @security_policies = SecurityPolicySection.new
       end
 
       # Method used by {.new_from_hashes} to populate the attributes.
@@ -67,18 +67,7 @@ module Y2Security
       # @param hash [Hash] see {.new_from_hashes}
       def init_from_hashes(hash)
         super
-        @security_policies = policies_from_hashes(hash)
-      end
-
-    private
-
-      # @return [Array<SecurityPolicySection>]
-      def policies_from_hashes(hash)
-        return [] unless hash["security_policies"]
-
-        hash["security_policies"].map do |policy|
-          SecurityPolicySection.new_from_hashes(policy, self)
-        end
+        @security_policies = SecurityPolicySection.new_from_hashes(hash["security_policies"], self)
       end
     end
   end

--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -946,26 +946,19 @@ module Yast
 
     # It enables the security policies according to the profile
     #
-    # @param sections [Array<Y2Security::AutoinstProfile::SecurityPolicySection>] security
-    #   policies sections from the AutoYaST profile
-    def import_security_policies(sections)
+    # @param sections [Y2Security::AutoinstProfile::SecurityPolicySection] security
+    #   policies section from the AutoYaST profile
+    def import_security_policies(section)
       manager = Y2Security::SecurityPolicies::Manager.instance
-      sections.each do |section|
-        policy = manager.find_policy(section.name&.to_sym)
+      manager.scap_action = section.action.to_sym if section.action
+      section.enabled_policies.each do |name|
+        policy = manager.find_policy(name&.to_sym)
         if policy.nil?
-          log.error "The security policy '#{section.name}' is unknown."
+          log.error "The security policy '#{name}' is unknown."
           next
         end
 
         manager.enable_policy(policy)
-        section.disabled_rules.each do |rule_id|
-          rule = policy.rules.find { |r| r.id == rule_id }
-          if rule.nil?
-            rule = Y2Security::SecurityPolicies::UnknownRule.new(rule_id)
-            policy.rules << rule
-          end
-          rule&.disable
-        end
       end
     end
 

--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -950,7 +950,13 @@ module Yast
     #   policies section from the AutoYaST profile
     def import_security_policies(section)
       manager = Y2Security::SecurityPolicies::Manager.instance
-      manager.scap_action = section.action.to_sym if section.action
+
+      begin
+        manager.scap_action = section.action.to_sym if section.action
+      rescue Y2Security::SecurityPolicies::Manager::UnknownSCAPAction
+        log.error("SCAP action '#{section.action}' is not valid.")
+      end
+
       section.enabled_policies.each do |name|
         policy = manager.find_policy(name&.to_sym)
         if policy.nil?

--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -944,10 +944,10 @@ module Yast
       PackagesProposal.SetResolvables("LSM", :pattern, lsm_config.needed_patterns)
     end
 
-    # It enables the security policies according to the profile
+    # It enables the security policy according to the profile
     #
-    # @param sections [Y2Security::AutoinstProfile::SecurityPolicySection] security
-    #   policies section from the AutoYaST profile
+    # @param section [Y2Security::AutoinstProfile::SecurityPolicySection] security
+    #   policy section from the AutoYaST profile
     def import_security_policy(section)
       return if section.policy.nil?
 

--- a/test/security_test.rb
+++ b/test/security_test.rb
@@ -819,6 +819,17 @@ module Yast
           expect(policies_manager.scap_action).to eq(:remediate)
         end
 
+        context "but a not valid SCAP action is given" do
+          let(:profile) do
+            { "action" => "unknown" }
+          end
+
+          it "logs an error" do
+            expect(subject.log).to receive(:error).with("SCAP action 'unknown' is not valid.")
+            subject.Import("SECURITY_POLICIES" => profile)
+          end
+        end
+
         context "but the policy does not exist" do
           let(:profile) do
             { "enabled_policies" => ["dummy"] }

--- a/test/security_test.rb
+++ b/test/security_test.rb
@@ -801,8 +801,8 @@ module Yast
 
         let(:profile) do
           {
-            "action"           => "remediate",
-            "enabled_policies" => ["stig"]
+            "action" => "remediate",
+            "policy" => "stig"
           }
         end
 
@@ -811,7 +811,7 @@ module Yast
         end
 
         it "enables the security policy" do
-          subject.Import("SECURITY_POLICIES" => profile)
+          subject.Import("SECURITY_POLICY" => profile)
           expect(policies_manager.enabled_policy?(policy)).to eq(true)
         end
 
@@ -821,23 +821,23 @@ module Yast
 
         context "but a not valid SCAP action is given" do
           let(:profile) do
-            { "action" => "unknown" }
+            { "action" => "unknown", "policy" => "stig" }
           end
 
           it "logs an error" do
             expect(subject.log).to receive(:error).with("SCAP action 'unknown' is not valid.")
-            subject.Import("SECURITY_POLICIES" => profile)
+            subject.Import("SECURITY_POLICY" => profile)
           end
         end
 
         context "but the policy does not exist" do
           let(:profile) do
-            { "enabled_policies" => ["dummy"] }
+            { "policy" => "dummy" }
           end
 
           it "logs an error" do
             expect(subject.log).to receive(:error).with("The security policy 'dummy' is unknown.")
-            subject.Import("SECURITY_POLICIES" => profile)
+            subject.Import("SECURITY_POLICY" => profile)
           end
         end
       end

--- a/test/y2security/autoinst_profile/security_policy_section_test.rb
+++ b/test/y2security/autoinst_profile/security_policy_section_test.rb
@@ -24,20 +24,20 @@ require "y2security/autoinst_profile/security_policy_section"
 describe Y2Security::AutoinstProfile::SecurityPolicySection do
   describe ".new_from_hashes" do
     let(:profile) do
-      { "name" => "disa_stig", "disabled_rules" => ["partition_for_home"] }
+      { "action" => "remediate", "enabled_policies" => ["stig"] }
     end
 
-    it "sets the name and the list of ignored rules" do
+    it "sets the SCAP action and the list of enabled policies" do
       section = described_class.new_from_hashes(profile)
-      expect(section.name).to eq("disa_stig")
-      expect(section.disabled_rules).to eq(["partition_for_home"])
+      expect(section.action).to eq("remediate")
+      expect(section.enabled_policies).to eq(["stig"])
     end
 
     context "an empty profile" do
       it "returns an empty section" do
         section = described_class.new_from_hashes({})
-        expect(section.name).to be_nil
-        expect(section.disabled_rules).to eq([])
+        expect(section.action).to be_nil
+        expect(section.enabled_policies).to eq([])
       end
     end
   end

--- a/test/y2security/autoinst_profile/security_policy_section_test.rb
+++ b/test/y2security/autoinst_profile/security_policy_section_test.rb
@@ -24,20 +24,20 @@ require "y2security/autoinst_profile/security_policy_section"
 describe Y2Security::AutoinstProfile::SecurityPolicySection do
   describe ".new_from_hashes" do
     let(:profile) do
-      { "action" => "remediate", "enabled_policies" => ["stig"] }
+      { "action" => "remediate", "policy" => "stig" }
     end
 
     it "sets the SCAP action and the list of enabled policies" do
       section = described_class.new_from_hashes(profile)
       expect(section.action).to eq("remediate")
-      expect(section.enabled_policies).to eq(["stig"])
+      expect(section.policy).to eq("stig")
     end
 
     context "an empty profile" do
       it "returns an empty section" do
         section = described_class.new_from_hashes({})
         expect(section.action).to be_nil
-        expect(section.enabled_policies).to eq([])
+        expect(section.policy).to be_nil
       end
     end
   end

--- a/test/y2security/autoinst_profile/security_section_test.rb
+++ b/test/y2security/autoinst_profile/security_section_test.rb
@@ -29,14 +29,14 @@ describe Y2Security::AutoinstProfile::SecuritySection do
       section = described_class.new_from_hashes(profile)
       expect(section.selinux_mode).to eql("enforcing")
       expect(section.lsm_select).to eql("selinux")
-      expect(section.security_policies.action).to be_nil
-      expect(section.security_policies.enabled_policies).to be_empty
+      expect(section.security_policy.action).to be_nil
+      expect(section.security_policy.policy).to be_nil
     end
 
     context "when a list of security policies is given" do
       let(:profile) do
         {
-          "security_policies" => {
+          "security_policy" => {
             "action" => "remediate", "enabled_policies" => ["stig"]
           }
         }
@@ -44,7 +44,7 @@ describe Y2Security::AutoinstProfile::SecuritySection do
 
       it "adds one section for each policy" do
         section = described_class.new_from_hashes(profile)
-        policy_section = section.security_policies
+        policy_section = section.security_policy
         expect(policy_section.action).to eq("remediate")
         expect(policy_section.parent).to eq(section)
       end

--- a/test/y2security/autoinst_profile/security_section_test.rb
+++ b/test/y2security/autoinst_profile/security_section_test.rb
@@ -29,22 +29,23 @@ describe Y2Security::AutoinstProfile::SecuritySection do
       section = described_class.new_from_hashes(profile)
       expect(section.selinux_mode).to eql("enforcing")
       expect(section.lsm_select).to eql("selinux")
-      expect(section.security_policies).to be_empty
+      expect(section.security_policies.action).to be_nil
+      expect(section.security_policies.enabled_policies).to be_empty
     end
 
     context "when a list of security policies is given" do
       let(:profile) do
         {
-          "security_policies" => [
-            { "name" => "disa_stig", "disabled_rules" => ["partition_for_home"] }
-          ]
+          "security_policies" => {
+            "action" => "remediate", "enabled_policies" => ["stig"]
+          }
         }
       end
 
       it "adds one section for each policy" do
         section = described_class.new_from_hashes(profile)
-        policy_section = section.security_policies.first
-        expect(policy_section.name).to eq("disa_stig")
+        policy_section = section.security_policies
+        expect(policy_section.action).to eq("remediate")
         expect(policy_section.parent).to eq(section)
       end
     end

--- a/test/y2security/security_policies/manager_test.rb
+++ b/test/y2security/security_policies/manager_test.rb
@@ -42,24 +42,24 @@ describe Y2Security::SecurityPolicies::Manager do
   end
 
   describe ".new" do
-    context "when YAST_SECURITY_POLICIES does not contain a policy" do
-      let(:env) { { "YAST_SECURITY_POLICIES" => "" } }
+    context "when YAST_SECURITY_POLICY does not contain a policy" do
+      let(:env) { { "YAST_SECURITY_POLICY" => "" } }
 
       it "does not enable a policy" do
         expect(subject.enabled_policies).to be_empty
       end
     end
 
-    context "when YAST_SECURITY_POLICIES contains an unknown policy" do
-      let(:env) { { "YAST_SECURITY_POLICIES" => "DisaStig" } }
+    context "when YAST_SECURITY_POLICY contains an unknown policy" do
+      let(:env) { { "YAST_SECURITY_POLICY" => "DisaStig" } }
 
       it "does not enable a policy" do
         expect(subject.enabled_policies).to be_empty
       end
     end
 
-    context "when YAST_SECURITY_POLICIES contains a known policy" do
-      let(:env) { { "YAST_SECURITY_POLICIES" => "foo,Stig" } }
+    context "when YAST_SECURITY_POLICY contains a known policy" do
+      let(:env) { { "YAST_SECURITY_POLICY" => "Stig" } }
 
       it "enables the policy" do
         expect(subject.enabled_policies).to contain_exactly(disa_stig_policy)


### PR DESCRIPTION
This PR adapts the AutoYaST bits of this module to support the new design/API. Bear in mind that only one security policy can be applied to a machine. As a consequence, the <security_policy>` section in an AutoYaST profile should look like this:

```xml
  <security>
    <security_policy>
      <action>remediate</action> <!-- none, remediate or scan -->
      <policy>stig</policy> <!-- mandatory -->
    </security_policy>
    <selinux_mode>permissive</selinux_mode>
    <lsm_select>selinux</lsm_select>
  </security>
```

The counterpart of this PR is https://github.com/yast/yast-autoinstallation/pull/845.

## TODO

- [x] Adapt the code that imports the settings
- [x] Do not crash when an unknown action is specified
- [x] Adapt the `rnc` file
- [x] Replace YAST_SECURITY_POLICIES with YAST_SECURITY_POLICY