### PR TITLE
Disable ssg-apply service if SCAP action is :none

### DIFF
--- a/package/yast2-security.changes
+++ b/package/yast2-security.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Nov  8 17:40:12 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Disable the ssg-apply service if the selected SCAP action is
+  "do nothing" (related to jsc#SLE-24764).
+- 4.4.16
+
+-------------------------------------------------------------------
 Mon Aug 29 13:14:15 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Add support for DISA STIG security policy validation

--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-security
-Version:        4.4.15
+Version:        4.4.16
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/lib/y2security/security_policies/manager.rb
+++ b/src/lib/y2security/security_policies/manager.rb
@@ -125,11 +125,10 @@ module Y2Security
         return unless enabled_policy
 
         write_failing_rules(config, enabled_policy)
-
+        adjust_service
         return if scap_action == :none
 
         write_config(enabled_policy)
-        enable_service
       end
 
     private
@@ -208,9 +207,13 @@ module Y2Security
       SERVICE_NAME = "ssg-apply".freeze
       private_constant :SERVICE_NAME
 
-      # Enables the ssg-apply service to remedy the system after the installation
-      def enable_service
-        Yast::Service.enable(SERVICE_NAME)
+      # Enables or disables the ssg-apply service according to the selected SCAP action
+      def adjust_service
+        if scap_action == :none
+          Yast::Service.disable(SERVICE_NAME)
+        else
+          Yast::Service.enable(SERVICE_NAME)
+        end
       end
 
       def add_package

--- a/test/y2security/security_policies/manager_test.rb
+++ b/test/y2security/security_policies/manager_test.rb
@@ -275,8 +275,8 @@ describe Y2Security::SecurityPolicies::Manager do
           expect(File).to_not exist(override_file_path)
         end
 
-        it "does not enable the service" do
-          expect(Yast::Service).to_not receive(:enable)
+        it "disables the service" do
+          expect(Yast::Service).to receive(:disable).with("ssg-apply")
           subject.write
         end
       end


### PR DESCRIPTION
## Problem

`ssg-apply` even if the user asked to do nothing during the 1st boot. The problem is `ssg-apply` enables itself using a post-script (see https://build.suse.de/package/view_file/home:andavis:GEHC:stig/ssg-apply/ssg-apply.spec?expand=1) and YaST does not disable the service (it does not expect that behaviour).

## Solution

Explicitly disable the `ssg-apply`. Morever, the package should be adjusted to not enable itself.