### PR TITLE
Fix for Crash during Saving [master]

### DIFF
--- a/package/yast2-security.changes
+++ b/package/yast2-security.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Dec  1 14:56:43 UTC 2022 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Fixed wrong steps count causing a crash during saving (bsc#1205918)
+- 4.5.4
+
+-------------------------------------------------------------------
 Tue Nov  8 17:40:12 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - Add support for DISA STIG security policy validation

--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-security
-Version:        4.5.3
+Version:        4.5.4
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -687,7 +687,7 @@ module Yast
 
       # Security read dialog caption
       caption = _("Saving Security Configuration")
-      steps = 4
+      steps = 5
 
       Progress.New(
         caption,


### PR DESCRIPTION
## Target Branch

_**This is the merge to master.** The original fix for SLE-15-SP4 is https://github.com/yast/yast-security/pull/149._

## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1205918


## Trello

https://trello.com/c/Wns8fhe8/


## Problem

While saving any changes in the YaST Security module, there is a crash (that is not reported to the user!) with this backtrace in the y2log:

```
2022-12-01 02:45:17 <3> susetest(9049) [Ruby]
  modules/Progress.rb(UpdateProgressBar):606
  Progress bar has only 4 steps, not 5.

------------- Backtrace begin -------------

.../modules/Progress.rb:606:in `UpdateProgressBar'
.../modules/Progress.rb:661:in `NextStep'
.../modules/Progress.rb:671:in `NextStage'
.../modules/Security.rb:764:in `Write'
.../include/security/complex.rb:50:in `WriteDialog'
.../include/security/wizards.rb:133:in `block in SecuritySequence'
.../vendor_ruby/3.1.0/yast/builtins.rb:546:in `eval'
.../modules/Sequencer.rb:247:in `WS_run'
.../modules/Sequencer.rb:318:in `block in Run'
.../modules/Sequencer.rb:310:in `loop'
.../modules/Sequencer.rb:310:in `Run'
.../include/security/wizards.rb:148:in `SecuritySequence'
.../vendor_ruby/3.1.0/yast/fun_ref.rb:33:in `call'
.../vendor_ruby/3.1.0/yast/fun_ref.rb:33:in `call'
.../modules/CommandLine.rb:1569:in `Run'
.../clients/security.rb:153:in `main'
.../clients/security.rb:264:in `<top (required)>'
.../vendor_ruby/3.1.0/yast/wfm.rb:345:in `eval'
.../vendor_ruby/3.1.0/yast/wfm.rb:345:in `run_client'
.../vendor_ruby/3.1.0/yast/wfm.rb:206:in `call_builtin'
.../vendor_ruby/3.1.0/yast/wfm.rb:206:in `call_builtin_wrapper'
.../vendor_ruby/3.1.0/yast/wfm.rb:195:in `CallFunction'
.../bin/y2start:68:in `<main>'

------------- Backtrace end ---------------
```

It appears that despite this, all changes are saved, but actually the last part is _not_ saved: The LSM settings. So all changes in that area that the user might have done are silently lost.


## Cause and Fix

During this change, a new step during saving the settings was added: https://github.com/yast/yast-security/commit/365ef0d14bb5ff256fa3dc43825723baef81b084

But the API of that `Progress` class expects the number of those steps to be passed separately, and that number was not increased from the formerly 4 to then 5 steps. That by itself was harmless, but when later another `Progress.NextStage` was added during saving the settings in `Security::Write()`, the `Progress` module raised an exception because the expected number of 4 steps was exceeded.

The fix is to simply increase the number of steps from the old 4 to the current 5.


## Affected Versions

- SLE-15 SP4 / Leap 15.4 (tested)
- Tumbleweed / Factory

Not affected (tested):

- SLE-15 SP3 / Leap 15.3
- SLE-15 SP2 / Leap 15.2
- earlier versions

## Related PR

- Fix for SLE-15-SP4: https://github.com/yast/yast-security/pull/149