### PR TITLE
Export security policy settings

### DIFF
--- a/package/yast2-security.changes
+++ b/package/yast2-security.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Dec  9 11:56:50 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- AutoYaST: export security policy settings (related to
+  jsc#SLE-24764).
+- 4.4.18
+
+-------------------------------------------------------------------
 Thu Dec  1 14:56:43 UTC 2022 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Fixed wrong steps count causing a crash during saving (bsc#1205918)

--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-security
-Version:        4.4.17
+Version:        4.4.18
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/lib/y2security/autoinst_profile/security_policy_section.rb
+++ b/src/lib/y2security/autoinst_profile/security_policy_section.rb
@@ -18,6 +18,10 @@
 # find current contact information at www.suse.com.
 
 require "installation/autoinst_profile/section_with_attributes"
+require "y2security/security_policies/manager"
+require "cfa/ssg_apply"
+
+Yast.import "Service"
 
 module Y2Security
   module AutoinstProfile
@@ -42,6 +46,21 @@ module Y2Security
       #   @return [String,nil] SCAP action to apply on first boot ("none", "scan" or "remediate")
       # @!attribute policy
       #   @return [String,nil] Enabled policy
+
+      # Clones the security policy settings from the underlying system
+      def self.new_from_system
+        file = CFA::SsgApply.load
+        section = new
+        return section if file.empty?
+
+        section.action = if Y2Security::SecurityPolicies::Manager.instance.service_enabled?
+          (file.remediate == "yes") ? "remediate" : "scan"
+        else
+          "none"
+        end
+        section.policy = file.profile
+        section
+      end
     end
   end
 end

--- a/src/lib/y2security/autoinst_profile/security_policy_section.rb
+++ b/src/lib/y2security/autoinst_profile/security_policy_section.rb
@@ -53,10 +53,12 @@ module Y2Security
         section = new
         return section if file.empty?
 
-        section.action = if Y2Security::SecurityPolicies::Manager.instance.service_enabled?
-          (file.remediate == "yes") ? "remediate" : "scan"
-        else
+        section.action = if !Y2Security::SecurityPolicies::Manager.instance.service_enabled?
           "none"
+        elsif file.remediate == "yes"
+          "remediate"
+        else
+          "scan"
         end
         section.policy = file.profile
         section

--- a/src/lib/y2security/security_policies/manager.rb
+++ b/src/lib/y2security/security_policies/manager.rb
@@ -131,6 +131,13 @@ module Y2Security
         write_config(enabled_policy)
       end
 
+      # Determines whether the service to scan/remediate the system is enabled or not
+      #
+      # @return [Boolean]
+      def service_enabled?
+        Yast::Service.enabled?(SERVICE_NAME)
+      end
+
     private
 
       # Writes custom configuration for the ssg-apply script

--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -853,7 +853,10 @@ module Yast
         settings["PASSWD_USE_CRACKLIB"] = settings.delete("PASSWD_USE_PWQUALITY")
       end
 
-      settings.merge(lsm_config.export)
+      merged_settings = settings.merge(lsm_config.export)
+      security_policy = export_security_policy
+      merged_settings.merge!("security_policy" => security_policy) unless security_policy.empty?
+      merged_settings
     end
 
     # Create a textual summary and a list of unconfigured cards
@@ -961,6 +964,14 @@ module Yast
       manager.scap_action = section.action.to_sym if section.action
     rescue Y2Security::SecurityPolicies::Manager::UnknownSCAPAction
       log.error("SCAP action '#{section.action}' is not valid.")
+    end
+
+    # Export security policy settings
+    #
+    # @return [Hash]
+    def export_security_policy
+      Y2Security::AutoinstProfile::SecurityPolicySection.new_from_system
+        .to_hashes
     end
 
     # Sets @missing_mandatory_services honoring the systemd aliases

--- a/test/security_test.rb
+++ b/test/security_test.rb
@@ -656,8 +656,17 @@ module Yast
     end
 
     describe "#Export" do
+      let(:security_policy_section) do
+        instance_double(
+          Y2Security::AutoinstProfile::SecurityPolicySection,
+          to_hashes: { "profile" => "stig" }
+        )
+      end
+
       before do
         Security.lsm_config.reset
+        allow(Y2Security::AutoinstProfile::SecurityPolicySection)
+          .to receive(:new_from_system).and_return(security_policy_section)
       end
 
       it "merges LSM settings" do
@@ -669,6 +678,22 @@ module Yast
         settings = Security.Export
         expect(settings["lsm_select"]).to eq("selinux")
         expect(settings["selinux_mode"]).to eq("permissive")
+      end
+
+      context "when there are no security_policy settings" do
+        let(:security_policy_section) do
+          instance_double(Y2Security::AutoinstProfile::SecurityPolicySection, to_hashes: {})
+        end
+
+        it "merges security policy settings" do
+          settings = Security.Export
+          expect(settings.keys).to_not include("security_policy")
+        end
+      end
+
+      it "merges security policy settings" do
+        settings = Security.Export
+        expect(settings["security_policy"]).to eq("profile" => "stig")
       end
     end
 

--- a/test/y2security/security_policies/manager_test.rb
+++ b/test/y2security/security_policies/manager_test.rb
@@ -330,4 +330,26 @@ describe Y2Security::SecurityPolicies::Manager do
       end
     end
   end
+
+  describe "#service_enabled?" do
+    before do
+      allow(Yast::Service).to receive(:enabled?).with("ssg-apply").and_return(enabled?)
+    end
+
+    context "when the ssg-apply service is enabled" do
+      let(:enabled?) { true }
+
+      it "returns true" do
+        expect(subject.service_enabled?).to eq(true)
+      end
+    end
+
+    context "when the ssg-apply service is disabled" do
+      let(:enabled?) { false }
+
+      it "returns false" do
+        expect(subject.service_enabled?).to eq(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Problem

The `security_policy` section is not exported when cloning a system with AutoYaST.

## Solution

If the `/etc/ssg-apply/override.conf` file exists (written by AutoYaST), infer and export the settings.

* If the `ssg-apply` is disabled, set the `action` to "none".
* If the `ssg-apply` is enabled...
  * ... and `remediate` is set to `yes` in the configuration, set the action to `remediate`.
  * ... and `remediate` is set to `no` in the configuration, set the action to `scan`.

## Testing

- Added a new unit test
- Tested manually