### PR TITLE
Always write override conf

### DIFF
--- a/package/yast2-security.changes
+++ b/package/yast2-security.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Dec 20 10:21:49 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Always write the ssg-apply configuration if a security policy
+  is enabled, even if the action is 'none' (related to
+  jsc#SLE-24764).
+- 4.4.19
+
+-------------------------------------------------------------------
 Fri Dec  9 11:56:50 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - AutoYaST: export security policy settings (related to

--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-security
-Version:        4.4.18
+Version:        4.4.19
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/lib/y2security/security_policies/manager.rb
+++ b/src/lib/y2security/security_policies/manager.rb
@@ -126,8 +126,6 @@ module Y2Security
 
         write_failing_rules(config, enabled_policy)
         adjust_service
-        return if scap_action == :none
-
         write_config(enabled_policy)
       end
 

--- a/test/y2security/security_policies/manager_test.rb
+++ b/test/y2security/security_policies/manager_test.rb
@@ -267,12 +267,19 @@ describe Y2Security::SecurityPolicies::Manager do
         expect(content).to eq("rule1\nrule2\n")
       end
 
+      it "writes the ssg-apply configuration" do
+        subject.write
+        expect(File).to exist(override_file_path)
+      end
+
       context "when neither checks or remedation are enabled" do
         let(:scap_action) { :none }
 
-        it "does not write the configuration" do
+        it "disables ssg-apply remediation" do
           subject.write
-          expect(File).to_not exist(override_file_path)
+          apply_file = CFA::SsgApply.load
+          expect(apply_file.remediate).to eq("no")
+          expect(apply_file.profile).to eq("stig")
         end
 
         it "disables the service" do


### PR DESCRIPTION
## Problem

AutoYaST does not clone the `<security_policy/>` section when the action is set to `none`:

```xml
<security_policy>
  <action>none</action>
  <profile>stig</profile>
</security_policy>
```

In that case, YaST does not write an `/etc/ssg-apply/override.conf` file, so there is no way to infer that security policy checks were enabled at installation time. Checking whether `ssg-apply` package is installed does not look like a valid way to determine it because you might get a `<security_policy/>` section just for installing the package.

## Solution

Starting in `yast2-security 4.4.19`, if a security policy is enabled at installation time, YaST *always* writes the `override.conf` file. So when cloning the system, it exports a `<security_policy/>` section if that file exists.

## Towards a better solution

This solution is good enough, but we would rather prefer to rely on a YaST-specific file. In that regard, we suggest using a `/etc/ssg-apply.d` directory where we could drop a YaST-specific file (e.g., `70-yast.conf`). That file would tell us that security policies were enabled during installation. Moreover, `ssg-apply` would behave similarly to other tools (`ls -d /etc/*.d /usr/etc/*.d`).

## Testing

- *Added a new unit test*
- *Tested manually*