### PR TITLE
Do not push empty value into login.defs model

### DIFF
--- a/package/yast2-security.changes
+++ b/package/yast2-security.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Feb 22 17:28:54 UTC 2023 - Michal Filka <mfilka@suse.com>
+
+- bsc#1208492
+  - do not store empty values in CFA login.defs empty value to
+    avoid crash when parsing according to login.defs lens
+- 4.5.6
+
+-------------------------------------------------------------------
 Tue Dec 20 10:21:49 UTC 2022 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - AutoYaST: export security policy settings (related to

--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-security
-Version:        4.5.5
+Version:        4.5.6
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -554,6 +554,11 @@ module Yast
     # Write login.defs configuration
     def write_shadow_config
       SHADOW_ATTRS.each do |attr|
+        # bsc#1208492 shadow config uses login.defs attr formatting
+        # like <Key><space>*<Value>, so empty value is not supported
+        # and moreover can cause crash in login.defs lens
+        next if @Settings[attr].nil? || @Settings[attr].empty?
+
         shadow_config.public_send("#{attr.to_s.downcase}=", @Settings[attr])
       end
       encr = @Settings.fetch("PASSWD_ENCRYPTION", default_encrypt_method)

--- a/test/security_test.rb
+++ b/test/security_test.rb
@@ -240,6 +240,15 @@ module Yast
         expect(shadow_config).to receive(:save)
         Security.write_shadow_config
       end
+
+      it "doesn't allow empty value to enter into model for an attribute" do
+        Security.Settings["USERADD_CMD"] = ""
+
+        expect(shadow_config).not_to receive(:useradd_cmd=)
+        expect(shadow_config).to receive(:save)
+
+        Security.write_shadow_config
+      end
     end
 
     describe "#write_lsm_config" do


### PR DESCRIPTION
## Problem

*Short description of the original problem.*

- [bsc#1208492](https://bugzilla.suse.com/show_bug.cgi?id=1208492)

It seems to be consequence of moving from ```/etc/login.defs``` to ```/etc/login.defs.d/70-yast.defs```.

Login.defs attributes cannot contain empty values (by definition).  The module contains a list of supported attributes which are handled in a way (one of them is e.g. USERADD_CMD which can be seen in the bug report above). ```/etc/login.defs``` used to contain all those attributes with some value, so the module internals were filled with some values. Since that changed and source file(s) needn't to exist, the internals are not correctly filled and an empty value could be used later when writing configuration.

## Solution

When preparing attributes for writing, filter out those with empty value


## Testing

- *Tested manually*
