### PR TITLE
Do a lazy initialization of network and security settings

### DIFF
--- a/package/yast2-security.changes
+++ b/package/yast2-security.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Oct 30 09:09:26 UTC 2023 - Knut Anderssen <kanderssen@suse.com>
+
+- Do not load the security settings from the security policy until
+  needed (bsc#1216615).
+- 4.5.7
+
+-------------------------------------------------------------------
 Wed Feb 22 17:28:54 UTC 2023 - Michal Filka <mfilka@suse.com>
 
 - bsc#1208492

--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-security
-Version:        4.5.6
+Version:        4.5.7
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/lib/y2security/security_policies/target_config.rb
+++ b/src/lib/y2security/security_policies/target_config.rb
@@ -41,17 +41,19 @@ module Y2Security
       # @return [Bootloader::BootloaderFactory]
       attr_accessor :bootloader
 
-      # @return [Y2Network::Config]
-      attr_accessor :network
-
-      # @return [Installation::SecuritySettings, nil] nil if yast2-installation is not available
-      attr_accessor :security
-
       def initialize
         @storage = default_devicegraph
-        @network = default_network_config
         @bootloader = default_bootloader
-        @security = default_security_settings
+      end
+
+      # @return [Y2Network::Config]
+      def network
+        default_network_config
+      end
+
+      # @return [Installation::SecuritySettings, nil] nil if yast2-installation is not available
+      def security
+        default_security_settings
       end
 
       # Default devicegraph


### PR DESCRIPTION
## Problem

The initialization of the TargetConfig creates an instance of the security_settings which reads the defaults for ssh, firewall and vnc from the skelcd even when it does not need this configuration at all causing problems when it is read to early during the workflow or when it is not needed as commented.

In the related bug, it adds the package firewalld because according to the skelcd it needs to be enabled even if in the profile it is disabled or removed.

- https://bugzilla.suse.com/show_bug.cgi?id=1216615

## Solution

Do a lazy initialization of the settings just when required.



## Testing

- *Tested manually*

