### PR TITLE
Drop Obsolete login.defs Scripts USERADD_CMD, USERDEL_PRECMD, USERDEL_POSTCMD, GROUPADD_CMD

### DIFF
--- a/package/yast2-security.changes
+++ b/package/yast2-security.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Sep 30 14:36:10 UTC 2024 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Drop obsolete USERADD_CMD, USERDEL_PRECMD, USERDEL_POSTCMD in
+  /etc/login.defs.d/70-yast.defs (bsc#1231006)
+- 5.0.2
+
+-------------------------------------------------------------------
 Tue Aug  6 11:34:20 UTC 2024 - Knut Anderssen <kanderssen@suse.com>
 
 - Do not load the security settings from the security policy until

--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-security
-Version:        5.0.1
+Version:        5.0.2
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/autoyast-rnc/security.rnc
+++ b/src/autoyast-rnc/security.rnc
@@ -65,9 +65,6 @@ sys_uid_min = element sys_uid_min { STRING }
 systohc = element systohc { STRING }
 uid_max = element uid_max { STRING }
 uid_min = element uid_min { STRING }
-useradd_cmd = element useradd_cmd { STRING }
-userdel_postcmd = element userdel_postcmd { STRING }
-userdel_precmd = element userdel_precmd { STRING }
 hibernate_system = element hibernate_system  { STRING }
 kernel.sysrq = element kernel.sysrq  { STRING }
 mandatory_services = element mandatory_services  { STRING }
@@ -125,9 +122,6 @@ y2_security =
   | systohc
   | uid_max
   | uid_min
-  | useradd_cmd
-  | userdel_postcmd
-  | userdel_precmd
   | hibernate_system
   | kernel.sysrq
   | mandatory_services

--- a/src/data/security/level1.yml
+++ b/src/data/security/level1.yml
@@ -29,9 +29,6 @@ SYS_UID_MAX:                      '499'
 SYS_UID_MIN:                      '100'
 UID_MAX:                          '60000'
 UID_MIN:                          '1000'
-USERADD_CMD:                      "/usr/sbin/useradd.local"
-USERDEL_POSTCMD:                  "/usr/sbin/userdel-post.local"
-USERDEL_PRECMD:                   "/usr/sbin/userdel-pre.local"
 kernel.sysrq:                     '0'
 net.ipv4.ip_forward:              false
 net.ipv4.tcp_syncookies:          true

--- a/src/data/security/level2.yml
+++ b/src/data/security/level2.yml
@@ -29,9 +29,6 @@ SYS_UID_MAX:                      '499'
 SYS_UID_MIN:                      '100'
 UID_MAX:                          '60000'
 UID_MIN:                          '1000'
-USERADD_CMD:                      "/usr/sbin/useradd.local"
-USERDEL_POSTCMD:                  "/usr/sbin/userdel-post.local"
-USERDEL_PRECMD:                   "/usr/sbin/userdel-pre.local"
 kernel.sysrq:                     '0'
 net.ipv4.ip_forward:              false
 net.ipv4.tcp_syncookies:          true

--- a/src/data/security/level3.yml
+++ b/src/data/security/level3.yml
@@ -29,9 +29,6 @@ SYS_UID_MAX:                      '499'
 SYS_UID_MIN:                      '100'
 UID_MAX:                          '60000'
 UID_MIN:                          '1000'
-USERADD_CMD:                      "/usr/sbin/useradd.local"
-USERDEL_POSTCMD:                  "/usr/sbin/userdel-post.local"
-USERDEL_PRECMD:                   "/usr/sbin/userdel-pre.local"
 kernel.sysrq:                     '0'
 net.ipv4.ip_forward:              false
 net.ipv4.tcp_syncookies:          true

--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -64,10 +64,7 @@ module Yast
       "SYS_UID_MAX",
       "SYS_UID_MIN",
       "SYS_GID_MAX",
-      "SYS_GID_MIN",
-      "USERADD_CMD",
-      "USERDEL_PRECMD",
-      "USERDEL_POSTCMD"
+      "SYS_GID_MIN"
     ].freeze
 
     attr_reader :display_manager
@@ -153,9 +150,6 @@ module Yast
         "SYS_UID_MIN"                               => "100",
         "SYS_GID_MAX"                               => "499",
         "SYS_GID_MIN"                               => "100",
-        "USERADD_CMD"                               => "/usr/sbin/useradd.local",
-        "USERDEL_PRECMD"                            => "/usr/sbin/userdel-pre.local",
-        "USERDEL_POSTCMD"                           => "/usr/sbin/userdel-post.local",
         "PASSWD_REMEMBER_HISTORY"                   => "0",
         "SYSLOG_ON_NO_ERROR"                        => "yes",
         "DISPLAYMANAGER_ROOT_LOGIN_REMOTE"          => "no",

--- a/test/data/system/etc/login.defs
+++ b/test/data/system/etc/login.defs
@@ -163,7 +163,7 @@ LOGIN_TIMEOUT		60
 # any combination of letters "frwh" (full name, room number, work
 # phone, home phone).  If not defined, no changes are allowed.
 # For backward compatibility, "yes" = "rwh" and "no" = "frwh".
-# 
+#
 CHFN_RESTRICT		rwh
 
 #
@@ -254,11 +254,4 @@ CREATE_HOME     no
 #
 #CHARACTER_CLASS                [A-Za-z_][A-Za-z0-9_.-]*[A-Za-z0-9_.$-]\?
 CHARACTER_CLASS         [ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_][ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_.-]*[ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_.$-]\?
-
-#
-# If defined, this command is run when adding a group.
-# It should rebuild any NIS database etc. to add the
-# new created group.
-#
-GROUPADD_CMD             /usr/sbin/groupadd.local
 

--- a/test/data/system/etc/login.defs
+++ b/test/data/system/etc/login.defs
@@ -217,8 +217,6 @@ DEFAULT_HOME	yes
 # It should remove any at/cron/print jobs etc. owned by
 # the user to be removed (passed as the first argument).
 #
-# See USERDEL_PRECMD/POSTCMD below.
-#
 #USERDEL_CMD	/usr/sbin/userdel_local
 
 #
@@ -263,25 +261,4 @@ CHARACTER_CLASS         [ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_][
 # new created group.
 #
 GROUPADD_CMD             /usr/sbin/groupadd.local
-
-#
-# If defined, this command is run when adding a user.
-# It should rebuild any NIS database etc. to add the
-# new created account.
-#
-USERADD_CMD             /usr/sbin/useradd.local
-
-#
-# If defined, this command is run before removing a user.
-# It should remove any at/cron/print jobs etc. owned by
-# the user to be removed.
-#
-USERDEL_PRECMD          /usr/sbin/userdel-pre.local
-
-#
-# If defined, this command is run after removing a user.
-# It should rebuild any NIS database etc. to remove the
-# account from it.
-#
-USERDEL_POSTCMD         /usr/sbin/userdel-post.local
 

--- a/test/security_test.rb
+++ b/test/security_test.rb
@@ -242,9 +242,9 @@ module Yast
       end
 
       it "doesn't allow empty value to enter into model for an attribute" do
-        Security.Settings["USERADD_CMD"] = ""
+        Security.Settings["ENCRYPT_METHOD"] = ""
 
-        expect(shadow_config).not_to receive(:useradd_cmd=)
+        expect(shadow_config).not_to receive(:encrypt_method=)
         expect(shadow_config).to receive(:save)
 
         Security.write_shadow_config


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1231006


## Trello

https://trello.com/c/YaAqN3hc/


## Target Branch

**This is for master / Factory only.** SLE-15-SPx / Leap 15.x still support those scripts.


## Problem

On Factory / Tumbleweed / Slowroll, after using the YaST security module, the `useradd` / `usermod`, / `userdel` commands complain about invalid configuration parameters:

```
sudo usermod -aG docker poltpolt

configuration error - unknown item 'USERADD_CMD' (notify administrator)
configuration error - unknown item 'USERDEL_PRECMD' (notify administrator)
configuration error - unknown item 'USERDEL_POSTCMD' (notify administrator)
```

## Cause

It turned out that these parameters came from `/etc/login.defs.d/70-yast.defs`, written by the YaST security module:

```
USERADD_CMD /usr/sbin/useradd.local
USERDEL_PRECMD /usr/sbin/userdel-pre.local
USERDEL_POSTCMD /usr/sbin/userdel-post.local
```

Neither are those parameters described in `man login.defs`, nor are the corresponding commands `/usr/sbin/user*.local` present on any recent Tumbleweed or Slowroll.

Notice that they are only written to that file if the user uses the YaST security module at least once and writes the new security configuarion to disk; if that module is never started, the parameters are not in that file, only the `UMASK 022` line.


### Software Archaeology

Investigation on older releases showed that they were part of SUSE-specific extensions of the _shadow_  suite, dating back as far as 2003.

They are still available on SLE-15-SPx or older (until back in 2003), but no longer in Factory: They were dropped with the fix for [bsc#1191578](https://bugzilla.suse.com/show_bug.cgi?id=1191578), but nobody told the YaST team about that change, so the problem went unnoticed until a community user used those `useradd` / `usermod` / `userdel` commands after using the YaST security module.

Further investigation showed that we also keep mentioning another parameter `GROUPADD_CMD` that was also SUSE specific, but removed even earlier: See also [bug #1121197 comment #14](https://bugzilla.suse.com/show_bug.cgi?id=1121197#c14). We never seem to write that one at any place of our code, though; but it is present in sample `login.defs` files, in tests and in our definition of the file format that we use for parsing.


### Upstream Parameter: USERDEL_CMD

Please notice that the `USERDEL_CMD` parameter is defined upstream by the _shadow_ suite and is still available, unlike those SUSE extensions. See also `man login.defs`.


## Fix

Removed all references to those parameters in yast-security so they are not written to that config file anymore.


## Test

Manual test in a Tumbleweed VM


## Related PRs

- https://github.com/yast/yast-yast2/pull/1313
- https://github.com/yast/yast-autoinstallation/pull/879
- https://github.com/yast/yast-users/pull/399

Notice that none of those PRs depend on one another; each one works fine by itself.
