### PR TITLE
adapt selinux behavior according to new jira (jsc#PED-12400)

### DIFF
--- a/package/yast2-security.changes
+++ b/package/yast2-security.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Apr  9 08:12:01 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
+
+- Do not write selinux mode to kernel command line and keep it only
+  in /etc/selinux/config (jsc#PED-12400)
+- 5.0.3
+
+-------------------------------------------------------------------
 Mon Sep 30 14:36:10 UTC 2024 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Drop obsolete USERADD_CMD, USERDEL_PRECMD, USERDEL_POSTCMD in

--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-security
-Version:        5.0.2
+Version:        5.0.3
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/lib/y2security/lsm/selinux.rb
+++ b/src/lib/y2security/lsm/selinux.rb
@@ -364,8 +364,8 @@ module Y2Security
           @id = id.to_sym
           @name = name
           @options = {
-            "security"  => "selinux",
-            "selinux"   => disable   ? "0" : "1",
+            "security" => "selinux",
+            "selinux"  => disable ? "0" : "1"
           }
         end
 

--- a/test/y2security/lsm/selinux_test.rb
+++ b/test/y2security/lsm/selinux_test.rb
@@ -268,9 +268,9 @@ describe Y2Security::LSM::Selinux do
 
     it "resets the kernel params it knows" do
       params = {
-        "lsm"       => :missing,
-        "security"  => :missing,
-        "selinux"   => :missing
+        "lsm"      => :missing,
+        "security" => :missing,
+        "selinux"  => :missing
       }
       expect(Yast::Bootloader).to receive(:modify_kernel_params)
         .with(params)


### PR DESCRIPTION
## Problem

Selinux mode should be driven by selinux config file instead of kernel parameter otherwise it can lead to system boot freeze.

- [*Bugzilla link*](https://bugzilla.suse.com/show_bug.cgi?id=1239717)
- https://jira.suse.com/browse/PED-12400


## Solution

Do not write kernel parameter for selinux mode and use only config file.


## Testing

- *Added a new unit test*
- *Tested manually* ( TW yast and also Agama )