### PR TITLE
write proper /etc/selinux/config, according to expected format

### DIFF
--- a/package/yast2-security.changes
+++ b/package/yast2-security.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Feb  5 13:18:03 UTC 2026 - Robert Frohl <rfrohl@suse.com>
+
+- write proper /etc/selinux/config according to expected format
+  (bsc#1257752)
+- 5.0.4
+
+-------------------------------------------------------------------
 Wed Apr  9 08:12:01 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
 
 - Do not write selinux mode to kernel command line and keep it only

--- a/package/yast2-security.spec
+++ b/package/yast2-security.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-security
-Version:        5.0.3
+Version:        5.0.4
 Release:        0
 Group:          System/YaST
 License:        GPL-2.0-only

--- a/src/lib/cfa/selinux.rb
+++ b/src/lib/cfa/selinux.rb
@@ -86,7 +86,7 @@ module CFA
     #
     # @note uses the simplevars lens instead of semanage because the latest is only available from
     #   augeas-lenses >= 1.12. See https://github.com/hercules-team/augeas/pull/594/files
-    LENS = "simplevars.lns".freeze
+    LENS = "shellvars.lns".freeze
     private_constant :LENS
   end
 end


### PR DESCRIPTION
Proper format should not carry additional spaces and should look like 

```
$ cat /etc/selinux/config
SELINUX=disabled
```

## Problem

The config file format that is generated will not be parsed by the selinux toolchain

- https://bugzilla.suse.com/show_bug.cgi?id=1257752


## Solution

Removes unnecessary whitespaces.


## Testing

- *Tested manually*


## Screenshots

*If the fix affects the UI attach some screenshots here.*

