### PR TITLE
Change minimum UID from 500 to 1000

### DIFF
--- a/src/modules/Security.rb
+++ b/src/modules/Security.rb
@@ -145,7 +145,7 @@ module Yast
         "DISABLE_STOP_ON_REMOVAL"                   => "no",
         "RUN_UPDATEDB_AS"                           => "nobody",
         "UID_MAX"                                   => "60000",
-        "UID_MIN"                                   => "500",
+        "UID_MIN"                                   => "1000",
         "SYS_UID_MAX"                               => "499",
         "SYS_UID_MIN"                               => "100",
         "SYS_GID_MAX"                               => "499",


### PR DESCRIPTION
## Problem

/etc/login.defs.d/70-yast.defs is being created with UID 500 instead of 1000 (bsc#1262458)


## Solution

Change UID_MIN from 500 to 1000 in Security.rb

